### PR TITLE
New polkawasm target release 0.28.1

### DIFF
--- a/Dockerfile.polkawasm
+++ b/Dockerfile.polkawasm
@@ -1,0 +1,35 @@
+# diffs
+# - prebuild LLVM
+# - WASI platform dependencies (wasi-libc, binaryen /lib submodules)
+
+FROM golang:1.19.5-bullseye AS tinygo-base
+
+ENV GO111MODULE=on
+ENV GOFLAGS="-buildvcs=false"
+
+# Add the LLVM 15 repo for Debian 11 Bullseye
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" | tee /etc/apt/sources.list.d/llvm.list
+
+# Install LLVM toolchain packages
+RUN apt-get update && apt-get install -y \
+  clang-15 lld-15 llvm-15-dev libclang-15-dev cmake ninja-build
+
+# Copy TinyGo repo
+COPY . /tinygo
+
+# Update submodule
+RUN cd /tinygo/ && \
+  rm -rf ./lib/*/ && \
+  git submodule sync && \
+  git submodule update --init --recursive --force lib/wasi-libc && \
+  git submodule update --init --recursive --force lib/binaryen
+
+# Build WASI libs, Bynaryen (wasm-opts dependency) and the TinyGo compiler
+RUN cd /tinygo/ && \
+  make wasi-libc binaryen && \
+  go install .
+
+WORKDIR /tinygo
+
+CMD ["tinygo"]

--- a/polkawasm.sh
+++ b/polkawasm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build --tag polkawasm/tinygo:0.28.1 -f Dockerfile.polkawasm .
+docker run --rm -it polkawasm/tinygo:0.28.1 bash

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows
+//go:build baremetal || js || windows || polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasi
+//go:build linux && !baremetal && !wasi && !polkawasm
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux
+//go:build darwin || (linux && !polkawasm)
 
 package os_test
 

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || windows
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || (linux && !polkawasm) || netbsd || openbsd || solaris || windows
 
 package os
 

--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,4 +1,4 @@
-//go:build !linux || baremetal
+//go:build !linux || baremetal || polkawasm
 
 package os
 

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 package os
 

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 package os_test
 

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || polkawasm || (wasm && !wasi)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/getpagesize_test.go
+++ b/src/os/getpagesize_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal && !polkawasm)
 
 package os_test
 

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal)
+//go:build windows || darwin || (linux && !baremetal && !polkawasm)
 
 package os_test
 

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !baremetal && !js && !wasi
+//go:build !windows && !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/pipe_test.go
+++ b/src/os/pipe_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal && !wasi)
+//go:build windows || darwin || (linux && !baremetal && !wasi && !polkawasm)
 
 // Copyright 2021 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/read_test.go
+++ b/src/os/read_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi
+//go:build baremetal || polkawasm || js || wasi
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_test.go
+++ b/src/os/removeall_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !js && !wasi)
+//go:build darwin || (linux && !baremetal && !js && !wasi && !polkawasm)
 
 // TODO: implement ReadDir on windows
 

--- a/src/os/seek_unix_bad.go
+++ b/src/os/seek_unix_bad.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi)
+//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi && !polkawasm)
 
 package os
 

--- a/src/os/stat_linux.go
+++ b/src/os/stat_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi)
+//go:build baremetal || polkawasm || (wasm && !wasi)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal)
+//go:build darwin || (linux && !baremetal && !polkawasm)
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -66,7 +66,7 @@ var (
 func align(ptr uintptr) uintptr {
 	// Align to 16, which is the alignment of max_align_t:
 	// https://godbolt.org/z/dYqTsWrGq
-	const heapAlign = 16
+	const heapAlign = 8
 	return (ptr + heapAlign - 1) &^ (heapAlign - 1)
 }
 

--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !custommalloc
+//go:build tinygo.wasm && !custommalloc && !polkawasm
 
 package runtime
 

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -3,9 +3,9 @@
 
 package runtime
 
-// This GC strategy allows an external GC to be plugged in instead of the builtin
-// implementations.
-//
+// Simple GC, that calls an external allocator. It does not free memory, but works faster
+// and memory is freed at the end of the execution from the external allocator.
+
 // The interface defined in this file is not stable and can be broken at anytime, even
 // across minor versions.
 //
@@ -36,28 +36,100 @@ import (
 	"unsafe"
 )
 
-// initHeap is called when the heap is first initialized at program start.
-func initHeap()
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
 
-// alloc is called to allocate memory. layout is currently not used.
-func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+const gcFrees = 0
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// Heap is initialized by the external allocator
+}
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Heap is in custom GC, so ignore it when called from wasm initialization.
+}
+
+// alloc tries to find free space on the heap to allocate memory,
+// If no space is free, it panics. layout is currently not used.
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	printstr("call alloc(")
+	printnum(int(size))
+	printstr(")\n")
+
+	if size == 0 {
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	printstr("\ttotal memory ")
+	printnum(int(gcTotalAlloc))
+	printstr("\n")
+
+	size = align(size)
+
+	// Try to bound heap growth.
+	if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+		printstr("\tout of memory\n")
+		abort()
+	}
+
+	// Allocate the memory.
+	pointer := extalloc(size)
+	if pointer == nil {
+		printstr("\textalloc call failed\n")
+		abort()
+	}
+
+	// Zero-out the allocated memory
+	memzero(pointer, size)
+
+	// Update used memory
+	gcTotalAlloc += uint64(size)
+
+	return pointer
+}
 
 // free is called to explicitly free a previously allocated pointer.
-func free(ptr unsafe.Pointer)
+func free(ptr unsafe.Pointer) {
+	// memory is never freed from the GC, but from the
+	// external allocator at the end of the execution
+}
 
 // markRoots is called with the start and end addresses to scan for references.
 // It is currently only called with the top and bottom of the stack.
-func markRoots(start, end uintptr)
+func markRoots(start, end uintptr) {
+
+}
 
 // GC is called to explicitly run garbage collection.
-func GC()
+func GC() {
+
+}
 
 // SetFinalizer registers a finalizer.
-func SetFinalizer(obj interface{}, finalizer interface{})
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+
+}
 
 // ReadMemStats populates m with memory statistics.
-func ReadMemStats(ms *MemStats)
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
 
-func setHeapEnd(newHeapEnd uintptr) {
-	// Heap is in custom GC so ignore for when called from wasm initialization.
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
 }

--- a/src/runtime/gc_custom_extalloc.go
+++ b/src/runtime/gc_custom_extalloc.go
@@ -1,0 +1,560 @@
+//go:build gc.custom_extalloc
+// +build gc.custom_extalloc
+
+package runtime
+
+// WIP
+
+// This is a conservative collector which uses an external memory allocator.
+// It keeps a list of allocations for tracking purposes.
+
+// This GC strategy allows an external GC to be plugged in instead of the builtin
+// implementations.
+//
+// The interface defined in this file is not stable and can be broken at anytime, even
+// across minor versions.
+//
+// runtime.markStack() must be called at the beginning of any GC cycle. //go:linkname
+// on a function without a body can be used to access this internal function.
+//
+// The custom implementation must provide the following functions in the runtime package
+// using the go:linkname directive:
+//
+// - func initHeap()
+// - func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// - func free(ptr unsafe.Pointer)
+// - func markRoots(start, end uintptr)
+// - func GC()
+// - func SetFinalizer(obj interface{}, finalizer interface{})
+// - func ReadMemStats(ms *runtime.MemStats)
+//
+//
+// In addition, if targeting wasi, the following functions should be exported for interoperability
+// with wasi libraries that use them. Note, this requires the export directive, not go:linkname.
+//
+// - func malloc(size uintptr) unsafe.Pointer
+// - func free(ptr unsafe.Pointer)
+// - func calloc(nmemb, size uintptr) unsafe.Pointer
+// - func realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer
+
+import (
+	"unsafe"
+)
+
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
+
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+var gcFrees uint64
+
+// This is used to detect if the collector is invoking itself or trying to allocate memory.
+var gcRunning bool
+
+// heapBound is used to control the growth of the heap.
+// When the heap exceeds this size, the garbage collector is run.
+// If the garbage collector cannot free up enough memory, the bound is doubled until the allocation fits.
+var heapBound uintptr = 4 * unsafe.Sizeof(unsafe.Pointer(nil))
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
+
+// scanQueue is a queue of marked allocations to scan.
+var scanQueue *allocListEntry
+
+var allocList []allocListEntry
+
+// allocListEntry is a listing of a single heap allocation.
+type allocListEntry struct {
+	start uintptr
+	end   uintptr
+	next  *allocListEntry
+}
+
+// scan marks all allocations referenced by this allocation.
+// This should only be invoked by the garbage collector.
+func (e *allocListEntry) scan() {
+	scan(e.start, e.end)
+}
+
+// scan loads all pointer-aligned words and marks any pointers that it finds.
+func scan(start uintptr, end uintptr) {
+	// Align start pointer.
+	start = (start + unsafe.Alignof(unsafe.Pointer(nil)) - 1) &^ (unsafe.Alignof(unsafe.Pointer(nil)) - 1)
+
+	// Mark all pointers.
+	for ptr := start; ptr+unsafe.Sizeof(unsafe.Pointer(nil)) <= end; ptr += unsafe.Alignof(unsafe.Pointer(nil)) {
+		mark(*(*uintptr)(unsafe.Pointer(ptr)))
+	}
+}
+
+// mark searches for an allocation containing the given address and marks it if found.
+func mark(addr uintptr) bool {
+	if len(allocList) == 0 {
+		// The heap is empty.
+		return false
+	}
+
+	if addr < allocList[0].start || addr > allocList[len(allocList)-1].end {
+		// Pointer is outside of allocated bounds.
+		return false
+	}
+
+	// Search the allocation list for this address.
+	alloc := searchAllocList(allocList, addr)
+	if alloc != nil && alloc.next == nil {
+		printstr("mark ")
+		printnum(int(addr))
+		printstr("\n")
+
+		// Push the allocation onto the scan queue.
+		next := scanQueue
+		if next == nil {
+			// Insert a loop so we can tell that this isn't marked.
+			next = alloc
+		}
+		scanQueue, alloc.next = alloc, next
+
+		return true
+	}
+
+	// The address does not reference an unmarked allocation.
+	return false
+}
+
+// searchAllocList searches a sorted alloc list for an address.
+// If the address is found in an allocation, a pointer to the corresponding entry is returned.
+// Otherwise, this returns nil.
+func searchAllocList(list []allocListEntry, addr uintptr) *allocListEntry {
+	for len(list) > 0 {
+		mid := len(list) / 2
+		switch {
+		case addr < list[mid].start:
+			list = list[:mid]
+		case addr > list[mid].end:
+			list = list[mid+1:]
+		default:
+			return &list[mid]
+		}
+	}
+
+	return nil
+}
+
+// sortAllocList sorts an allocation list using heapsort.
+//
+//go:noinline
+func sortAllocList(list []allocListEntry) {
+	// Turn the array into a max heap.
+	for i, v := range list {
+		// Repeatedly swap v up the heap until the node above is at a greater address (or the top of the heap is reached).
+		for i > 0 && v.start > list[(i-1)/2].start {
+			list[i] = list[(i-1)/2]
+			i = (i - 1) / 2
+		}
+		list[i] = v
+	}
+
+	// Repeatedly remove the max and place it at the end of the array.
+	for len(list) > 1 {
+		// Remove the max and place it at the end of the array.
+		list[0], list[len(list)-1] = list[len(list)-1], list[0]
+		list = list[:len(list)-1]
+
+		// Fix the position of the element we swapped into the root.
+		i := 0
+		for {
+			// Find the element that should actually be at this position.
+			max := i
+			if l := 2*i + 1; l < len(list) && list[l].start > list[max].start {
+				max = l
+			}
+			if r := 2*i + 2; r < len(list) && list[r].start > list[max].start {
+				max = r
+			}
+
+			if max == i {
+				// The element is where it is supposed to be.
+				break
+			}
+
+			// Swap this element down the heap.
+			list[i], list[max] = list[max], list[i]
+			i = max
+		}
+	}
+}
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// Heap is initialized by the external allocator
+}
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Heap is in custom GC, so ignore it when called from wasm initialization.
+}
+
+// alloc tries to find free space on the heap to allocate memory,
+// possibly doing a garbage collection cycle if needed. If no space
+// is free, it panics. layout is currently not used.
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	printstr("call alloc(")
+	printnum(int(size))
+	printstr(")\n")
+
+	if size == 0 {
+		printstr("zero-size allocation\n")
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	if gcRunning {
+		printstr("aborting, called alloc during GC cycle\n")
+		abort()
+	}
+
+	size = align(size)
+	gcMallocs++
+
+	var gcRan bool
+	for {
+		// Try to bound heap growth.
+		if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+			printstr("total memory")
+			printnum(int(gcTotalAlloc))
+			printstr("\n")
+			printstr("target heap size exceeds address space\n")
+			abort()
+		}
+
+		if gcTotalAlloc+uint64(size) > uint64(heapBound) {
+			if !gcRan {
+				printstr("reached the heap size limit\n")
+				// Run the garbage collector before growing the heap.
+				GC()
+				gcRan = true
+				continue
+			} else {
+				// Grow the heap bound to fit the allocation.
+				for heapBound != 0 && uintptr(gcTotalAlloc)+size > heapBound {
+					heapBound <<= 1
+				}
+				if heapBound == 0 {
+					// This is only possible on hosted 32-bit systems.
+					// Allow the heap bound to encompass everything.
+					heapBound = ^uintptr(0)
+				}
+				printstr("increased the heap size limit to ")
+				printnum(int(heapBound))
+				printstr("\n")
+			}
+		}
+
+		// Ensure that there is space in the alloc list.
+		if len(allocList) == cap(allocList) {
+			printstr("alloc list is full\n")
+
+			// Attempt to double the size of the alloc list.
+			newCap := 2 * uintptr(cap(allocList))
+			if newCap == 0 {
+				newCap = 1
+			}
+
+			printstr("increase the capacity from ")
+			printnum(cap(allocList))
+			printstr(" to ")
+			printnum(int(newCap))
+			printstr("\n")
+
+			// oldList := allocList
+
+			oldListHeader := (*struct {
+				ptr unsafe.Pointer
+				len uintptr
+				cap uintptr
+			})(unsafe.Pointer(&allocList))
+
+			printstr("old list\n")
+			printstr("\tstart ")
+			printnum(int(uintptr(oldListHeader.ptr)))
+			printstr("\tend ")
+			printnum(int(uintptr(oldListHeader.ptr) + oldListHeader.cap*unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			printstr("try to allocate memory for the new alloc list with size ")
+			printnum(int(newCap * unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			newListPtr := extalloc(newCap * unsafe.Sizeof(allocListEntry{}))
+			if newListPtr == nil {
+				printstr("call to extalloc failed")
+
+				if gcRan {
+					// Garbage collector was not able to free up enough memory.
+					printstr("out of memory\n")
+					abort()
+				} else {
+					// Run the garbage collector and try again.
+					GC()
+					gcRan = true
+					continue
+				}
+			}
+
+			newListHeader := (*struct {
+				ptr unsafe.Pointer
+				len uintptr
+				cap uintptr
+			})(unsafe.Pointer(&allocList))
+			newListHeader.ptr = newListPtr
+			newListHeader.len = oldListHeader.len // uintptr(len(oldList))
+			newListHeader.cap = newCap
+
+			// copy(allocList, oldList)
+			// for i := range oldList {
+			// 	*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = oldList[i]
+			// }
+			for i := 0; i < int(oldListHeader.len); i++ {
+				*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = *(*allocListEntry)(unsafe.Pointer(uintptr(oldListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{})))
+			}
+
+			printstr("new list\n")
+			printstr("\tstart ")
+			printnum(int(uintptr(newListHeader.ptr)))
+			printstr("\tend ")
+			printnum(int(uintptr(newListHeader.ptr) + newListHeader.cap*unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			if oldListHeader.cap != 0 { // cap(oldList)
+				printstr("free the old alloc list\n")
+				free(oldListHeader.ptr) // unsafe.Pointer(&oldList[0])
+			}
+		}
+
+		// Allocate the memory.
+		pointer := extalloc(size)
+		if pointer == nil {
+			printstr("\textalloc call failed\n")
+
+			if gcRan {
+				// Garbage collector was not able to free up enough memory.
+				printstr("out of memory\n")
+				abort()
+			} else {
+				// Run the garbage collector and try again.
+				GC()
+				gcRan = true
+				continue
+			}
+		}
+
+		// Add the allocation to the list.
+		i := len(allocList)
+		// allocList = allocList[:i+1]
+		// allocList[i] = allocListEntry{
+		// 	start: uintptr(pointer),
+		// 	end:   uintptr(pointer) + size,
+		// }
+
+		newListHeader := (*struct {
+			ptr unsafe.Pointer
+			len uintptr
+			cap uintptr
+		})(unsafe.Pointer(&allocList))
+
+		*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = allocListEntry{
+			start: uintptr(pointer),
+			end:   uintptr(pointer) + size,
+		}
+
+		newListHeader.len = uintptr(i + 1)
+
+		// printstr("updated new alloc list\n")
+		// printstr("\tlength ")
+		// printnum(len(allocList))
+		// printstr("\n")
+		// printstr("\tcapacity ")
+		// printnum(cap(allocList))
+		// printstr("\n")
+
+		// Zero-out the allocated memory
+		memzero(pointer, size)
+
+		// Update used memory
+		gcTotalAlloc += uint64(size)
+
+		printstr("total memory ")
+		printnum(int(gcTotalAlloc))
+		printstr("\n")
+
+		return pointer
+	}
+}
+
+// free is called to explicitly free a previously allocated pointer.
+func free(ptr unsafe.Pointer) {
+	printstr("call free(")
+	printnum(int(uintptr(ptr)))
+	printstr(")\n")
+	gcFrees++
+	extfree(ptr)
+}
+
+// markRoots is called with the start and end addresses to scan for references.
+// It is currently only called with the top and bottom of the stack.
+func markRoots(start, end uintptr) {
+	scan(start, end)
+}
+
+func markRoot(addr uintptr, root uintptr) {
+	mark(root)
+}
+
+// GC is called to explicitly run garbage collection.
+func GC() {
+	// printstr("call GC()\n")
+
+	// if gcRunning {
+	// 	printstr("aborting recursive GC() call\n")
+	// 	abort()
+	// }
+	// gcRunning = true
+
+	// printstr("non-sorted pre-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// // Sort the allocation list so that it can be efficiently searched.
+	// sortAllocList(allocList)
+
+	// // Unmark all allocations.
+	// for i := range allocList {
+	// 	allocList[i].next = nil
+	// }
+
+	// // Reset the scan queue.
+	// scanQueue = nil
+
+	// printstr("pre-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// if len(allocList) > 1 {
+	// 	for i, _ := range allocList[1:] {
+	// 		if allocList[i+1].start < allocList[i].start { // <= ?
+	// 			printstr("alloc list is not sorted\n")
+	// 			abort()
+	// 		}
+	// 	}
+	// }
+
+	// // Start by scanning the stack.
+	// // markStack()
+
+	// // Scan all globals.
+	// // markGlobals()
+
+	// // Channel operations in interrupts may move task pointers around while we are marking.
+	// // Therefore we need to scan the runqueue seperately.
+	// // 	var markedTaskQueue task.Queue
+	// // runqueueScan:
+	// // 	for !runqueue.Empty() {
+	// // 		// Pop the next task off of the runqueue.
+	// // 		t := runqueue.Pop()
+
+	// // 		// Mark the task if it has not already been marked.
+	// // 		markRoot(uintptr(unsafe.Pointer(&runqueue)), uintptr(unsafe.Pointer(t)))
+
+	// // 		// Push the task onto our temporary queue.
+	// // 		markedTaskQueue.Push(t)
+	// // 	}
+
+	// // Scan all referenced allocations.
+	// // for scanQueue != nil {
+	// // 	// Pop a marked allocation off of the scan queue.
+	// // 	alloc := scanQueue
+	// // 	next := alloc.next
+	// // 	if next == alloc {
+	// // 		// This is the last value on the queue.
+	// // 		next = nil
+	// // 	}
+	// // 	scanQueue = next
+
+	// // 	// Scan and mark all allocations that this references.
+	// // 	alloc.scan()
+	// // }
+
+	// // i := interrupt.Disable()
+	// // if !runqueue.Empty() {
+	// // 	// Something new came in while finishing the mark.
+	// // 	interrupt.Restore(i)
+	// // 	goto runqueueScan
+	// // }
+	// // runqueue = markedTaskQueue
+	// // interrupt.Restore(i)
+
+	// // Free all remaining unmarked allocations.
+	// // gcTotalAlloc = 0
+	// // j := 0
+	// // for _, v := range allocList {
+	// // 	if v.next == nil {
+	// // 		// This was never marked.
+	// // 		free(unsafe.Pointer(v.start))
+	// // 		continue
+	// // 	}
+
+	// // 	// Move this down in the list.
+	// // 	allocList[j] = v
+	// // 	j++
+
+	// // 	// Re-calculate used memory.
+	// // 	gcTotalAlloc += uint64(v.end - v.start)
+	// // }
+	// // allocList = allocList[:j]
+
+	// printstr("post-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// gcRunning = false
+}
+
+// SetFinalizer registers a finalizer.
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// TODO
+}
+
+// ReadMemStats populates m with memory statistics.
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
+
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
+}

--- a/src/runtime/gc_debug.go
+++ b/src/runtime/gc_debug.go
@@ -1,0 +1,71 @@
+//go:build gc.custom || gc.custom_extalloc
+
+package runtime
+
+const gcDebug = false
+
+func printnum(num int) {
+	digits := [10]int{}
+
+	for i := 0; num > 0; i++ {
+		digit := num % 10
+		digits[i] = digit
+		num = num / 10
+	}
+
+	for i := 0; i < len(digits)/2; i++ {
+		j := len(digits) - i - 1
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+
+	skipZeros := true
+	for i := 0; i < len(digits); i++ {
+		digit := digits[i]
+		if skipZeros && digit == 0 {
+			continue
+		}
+		skipZeros = false
+
+		digitStr := ""
+
+		switch digit {
+		case 0:
+			digitStr = "0"
+		case 1:
+			digitStr = "1"
+		case 2:
+			digitStr = "2"
+		case 3:
+			digitStr = "3"
+		case 4:
+			digitStr = "4"
+		case 5:
+			digitStr = "5"
+		case 6:
+			digitStr = "6"
+		case 7:
+			digitStr = "7"
+		case 8:
+			digitStr = "8"
+		case 9:
+			digitStr = "9"
+		default:
+		}
+
+		printstr(digitStr)
+	}
+}
+
+func printstr(str string) {
+	if !gcDebug {
+		return
+	}
+
+	for i := 0; i < len(str); i++ {
+		if putcharPosition >= putcharBufferSize {
+			break
+		}
+
+		putchar(str[i])
+	}
+}

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal && !nintendoswitch && !wasi
+//go:build linux && !baremetal && !nintendoswitch && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/os_other.go
+++ b/src/runtime/os_other.go
@@ -1,4 +1,4 @@
-//go:build linux && (baremetal || nintendoswitch || wasi)
+//go:build linux && (baremetal || nintendoswitch || wasi || polkawasm)
 
 // Other systems that aren't operating systems supported by the Go toolchain
 // need to pretend to be an existing operating system. Linux seems like a good

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,17 +2,13 @@
 
 package runtime
 
-import (
-	"unsafe"
-)
-
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-}
+// //export _start
+// func _start() {
+// 	// These need to be initialized early so that the heap can be initialized.
+// 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+// 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+// 	run()
+// }
 
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -1,0 +1,77 @@
+//go:build polkawasm
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//export _start
+func _start() {
+	// These need to be initialized early so that the heap can be initialized.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	run()
+}
+
+// Abort executes the wasm 'unreachable' instruction.
+func abort() {
+	trap()
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	return []string{}
+}
+
+func putchar(c byte) {
+}
+
+func getchar() byte {
+	return 0
+}
+
+func buffered() int {
+	return 0
+}
+
+type timeUnit int64
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	panic("unimplemented: ticksToNanoseconds")
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	panic("unimplemented: nanosecondsToTicks")
+}
+
+func sleepTicks(d timeUnit) {
+	panic("unimplemented: sleepTicks")
+}
+
+func ticks() timeUnit {
+	panic("unimplemented: ticks")
+}
+
+//go:linkname now time.now
+func now() (int64, int32, int64) {
+	panic("unimplemented: now")
+}
+
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	return
+}
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+}

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,6 +2,8 @@
 
 package runtime
 
+import "unsafe"
+
 // //export _start
 // func _start() {
 // 	// These need to be initialized early so that the heap can be initialized.
@@ -10,22 +12,27 @@ package runtime
 // 	run()
 // }
 
+// Using global variables to avoid heap allocation.
+const putcharBufferSize = 256 // increase the debug output size
+
+var (
+	putcharBuffer        = [putcharBufferSize]byte{}
+	putcharPosition uint = 0
+)
+
+// //go:export _debug_buf
+// func debugBuf() uintptr {
+// 	return uintptr(unsafe.Pointer(&putcharBuffer[0]))
+// }
+
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
 }
 
-//go:linkname os_runtime_args os.runtime_args
-func os_runtime_args() []string {
-	return []string{}
-}
-
-//go:linkname syscall_runtime_envs syscall.runtime_envs
-func syscall_runtime_envs() []string {
-	return []string{}
-}
-
 func putchar(c byte) {
+	putcharBuffer[putcharPosition] = c
+	putcharPosition++
 }
 
 func getchar() byte {
@@ -55,8 +62,18 @@ func ticks() timeUnit {
 }
 
 //go:linkname now time.now
-func now() (int64, int32, int64) {
+func now() (sec int64, nsec int32, mono int64) {
 	panic("unimplemented: now")
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	panic("unimplemented: syscall_runtime_envs")
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
 }
 
 //go:linkname syscall_Exit syscall.Exit
@@ -66,8 +83,18 @@ func syscall_Exit(code int) {
 
 //go:linkname procPin sync/atomic.runtime_procPin
 func procPin() {
+
 }
 
 //go:linkname procUnpin sync/atomic.runtime_procUnpin
 func procUnpin() {
+
 }
+
+//go:wasm-module env
+//go:export ext_allocator_malloc_version_1
+func extalloc(size uintptr) unsafe.Pointer
+
+//go:wasm-module env
+//go:export ext_allocator_free_version_1
+func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -91,10 +91,8 @@ func procUnpin() {
 
 }
 
-//go:wasm-module env
-//go:export ext_allocator_malloc_version_1
+//go:wasmimport env ext_allocator_malloc_version_1
 func extalloc(size uintptr) unsafe.Pointer
 
-//go:wasm-module env
-//go:export ext_allocator_free_version_1
+//go:wasmimport env ext_allocator_free_version_1
 func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm
+//go:build tinygo.wasm && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch
+//go:build (darwin || (linux && !baremetal && !wasi && !polkawasm)) && !nintendoswitch
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi
+//go:build wasm && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !scheduler.none
+//go:build wasm && !wasi && !polkawasm && !scheduler.none
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && wasi
+//go:build tinygo.wasm && wasi && !polkawasm
 
 package runtime
 

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasm
+//go:build baremetal || wasm || polkawasm
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasm
+//go:build !baremetal && !wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || wasi || wasm
+//go:build baremetal || wasi || wasm || polkawasm
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !wasi && !wasm
+//go:build !baremetal && !wasi && !wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || polkawasm
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js
+//go:build baremetal || nintendoswitch || js || polkawasm
 
 package syscall
 

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,9 +9,10 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
+	"gc": "conservative",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
-	"scheduler": "asyncify",
+	"scheduler": "none",
 	"default-stack-size": 16384,
 	"cflags": [
 		"-mbulk-memory",
@@ -19,8 +20,14 @@
 		"-msign-ext"
 	],
 	"ldflags": [
+		"--initial-memory=1310720",
+		"--no-demangle",
 		"--stack-first",
-		"--no-demangle"
+		"--import-memory",
+		"--allow-undefined",
+		"--export=__heap_base",
+		"--export=__data_end",
+		"--export-table"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,0 +1,30 @@
+{
+	"llvm-target": "wasm32-unknown-unknown",
+	"cpu": "generic",
+	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"build-tags": [
+		"tinygo.wasm",
+		"polkawasm",
+		"runtime_memhash_leveldb"
+	],
+	"goos": "linux",
+	"goarch": "arm",
+	"linker": "wasm-ld",
+	"libc": "wasi-libc",
+	"scheduler": "asyncify",
+	"default-stack-size": 16384,
+	"cflags": [
+		"-mbulk-memory",
+		"-mnontrapping-fptoint",
+		"-msign-ext"
+	],
+	"ldflags": [
+		"--stack-first",
+		"--no-demangle"
+	],
+	"extra-files": [
+		"src/runtime/asm_tinygowasm.S"
+	],
+	"emulator": "wasmtime {}",
+	"wasm-abi": "generic"
+}

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "wasm32-unknown-unknown",
 	"cpu": "generic",
-	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features": "",
 	"build-tags": [
 		"tinygo.wasm",
 		"polkawasm",
@@ -14,11 +14,7 @@
 	"libc": "wasi-libc",
 	"scheduler": "none",
 	"default-stack-size": 16384,
-	"cflags": [
-		"-mbulk-memory",
-		"-mnontrapping-fptoint",
-		"-msign-ext"
-	],
+	"cflags": [],
 	"ldflags": [
 		"--initial-memory=1310720",
 		"--no-demangle",

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -23,11 +23,12 @@
 		"--allow-undefined",
 		"--export=__heap_base",
 		"--export=__data_end",
-		"--export-table"
+		"--export-table",
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator": "wasmtime {}",
+	"emulator": "wasmtime --mapdir=/tmp::{tmpDir} {}",
 	"wasm-abi": "generic"
 }

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,7 +9,7 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
-	"gc": "conservative",
+	"gc": "custom",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
 	"scheduler": "none",


### PR DESCRIPTION
### Changes
🎯  New `polkawasm` target, targeting standalone **Wasm MVP**, similar to Rust's `wasm32-unknown-unknown`, but also incorporating **custom GC** that utilizes an external allocator. Based on Tinygo 0.28.1.

- [x] add custom Dockerfile and build script (with pre-build llvm)
- [x] add target implementation separate from the existing `wasm/wasi`
- [x] allow undefined (custom exported functions)
- [x] export globals and tables (`__heap_base`, `__data_end`)
- [x] import memory
- [ ] ~~change stack placement~~(no need, for now)
- [x] disable the scheduler (remove the support of goroutines and channels)
- [x] use `wasi-libc` with bulk memory ops disabled [wasi-libc pr](https://github.com/LimeChain/wasi-libc/pull/1) instead of providing own implementation. Not using `-opt=0` drops the size significantly, ~400KB
- [x] remove `_start` export (not supported from the host and not required with the `custom extalloc gc`)
- [x] remove `wasm-libc` exported allocation functions
- [x] add custom gc implementations
  - [x] one that allocates memory through an external allocator, but it is not freed from the gc
  - [ ] second one (WIP), both allocates and frees memory through the external allocator
- [ ] add tests for the `polkawasm` target + the `custom gc`

⚠️ **Issue(s)**:
Check [gosemble pr](https://github.com/LimeChain/gosemble/pull/131)
