### PR TITLE
New polkawasm target dev

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -21,11 +21,11 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install qemu binaryen
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
@@ -106,7 +106,7 @@ jobs:
         # - have a double-zipped artifact when downloaded from the UI
         # - have a very slow artifact upload
         # We're doing the former here, to keep artifact uploads fast.
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: darwin-amd64-double-zipped
           path: build/tinygo.darwin-amd64.tar.gz
@@ -132,9 +132,9 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm@${{ matrix.version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,14 +28,14 @@ jobs:
           sudo rm -rf /usr/local/graalvm
           sudo rm -rf /usr/local/share/boost
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             tinygo/tinygo-dev
@@ -44,18 +44,18 @@ jobs:
             type=sha,format=long
             type=raw,value=latest
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Log in to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,14 @@ jobs:
       packages: write
       contents: read
     steps:
+      - name: Free Disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/graalvm
+          sudo rm -rf /usr/local/share/boost
       - name: Check out the repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
         # We're not on a multi-user machine, so this is safe.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Cache Go
@@ -131,9 +131,9 @@ jobs:
     needs: build-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
@@ -161,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install apt dependencies
@@ -176,12 +176,12 @@ jobs:
               simavr \
               ninja-build
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
       - name: Install wasmtime
@@ -290,7 +290,7 @@ jobs:
     needs: build-linux
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install apt dependencies
         run: |
           sudo apt-get update
@@ -299,7 +299,7 @@ jobs:
               g++-${{ matrix.toolchain }} \
               libc6-dev-${{ matrix.libc }}-cross
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -25,14 +25,14 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             tinygo/llvm-16
@@ -46,13 +46,13 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Log in to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           target: tinygo-llvm-build
           context: .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Pull musl
         run: |
             git submodule update --init lib/musl

--- a/.github/workflows/sizediff.yml
+++ b/.github/workflows/sizediff.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo "$HOME/go/bin" >> $GITHUB_PATH
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch all history (no sparse checkout)
           submodules: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,11 +29,11 @@ jobs:
         run: |
           scoop install ninja binaryen
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
@@ -139,14 +139,14 @@ jobs:
         run: |
           scoop install binaryen
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
       - name: Download TinyGo build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-amd64-double-zipped
           path: build/
@@ -169,14 +169,14 @@ jobs:
           maximum-size: 24GB
           disk-root: "C:"
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true
       - name: Download TinyGo build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: windows-amd64-double-zipped
           path: build/
@@ -205,9 +205,9 @@ jobs:
         run: |
           scoop install binaryen && scoop install wasmtime@14.0.4
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21'
           cache: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 	branch = main
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc
-	url = https://github.com/WebAssembly/wasi-libc
+	url = https://github.com/LimeChain/wasi-libc
 [submodule "lib/picolibc"]
 	path = lib/picolibc
 	url = https://github.com/keith-packard/picolibc.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
         /var/tmp/* \
         /tmp/*
 
-COPY ./Makefile /tinygo/Makefile
+COPY ./GNUmakefile /tinygo/GNUmakefile
 
 RUN cd /tinygo/ && \
     make llvm-source

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,12 @@
 FROM golang:1.21 AS tinygo-llvm
 
 RUN apt-get update && \
-    apt-get install -y apt-utils make cmake clang-15 ninja-build
+    apt-get install -y apt-utils make cmake clang-15 ninja-build && \
+    rm -rf \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/tmp/* \
+        /tmp/*
 
 COPY ./Makefile /tinygo/Makefile
 

--- a/Dockerfile.polkawasm
+++ b/Dockerfile.polkawasm
@@ -1,0 +1,33 @@
+# Diffs:
+# - prebuild LLVM
+
+FROM golang:1.21-bullseye AS tinygo-base
+
+ENV GO111MODULE=on
+ENV GOFLAGS="-buildvcs=false"
+
+# Add the LLVM 16 repo for Debian 11 Bullseye
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-16 main" | tee /etc/apt/sources.list.d/llvm.list
+
+# Install LLVM toolchain packages
+RUN apt-get update && apt-get install -y \
+  clang-16 lld-16 llvm-16-dev libclang-16-dev cmake ninja-build
+
+# Copy TinyGo repo
+COPY . /tinygo
+
+WORKDIR /tinygo/lib/binaryen
+
+# Install binaryen(wasm-opt) 
+RUN cmake . && make
+
+ENV WASMOPT="/tinygo/lib/binaryen/bin/wasm-opt"
+
+WORKDIR /tinygo
+
+# Build wasi-libc and tinygo compiler
+RUN make wasi-libc && \
+  go install .
+
+CMD ["tinygo"]

--- a/builder/build.go
+++ b/builder/build.go
@@ -823,6 +823,10 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					"--output", result.Executable,
 				)
 
+				if config.Target.Triple == "wasm32-unknown-polkawasm" {
+					args = append(args, "--signext-lowering")
+				}
+
 				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr

--- a/builder/build.go
+++ b/builder/build.go
@@ -816,20 +816,32 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					args = append(args, "--asyncify")
 				}
 
-				args = append(args,
-					opt,
-					"-g",
-					result.Executable,
-					"--output", result.Executable,
-				)
-
 				if config.Target.Triple == "wasm32-unknown-polkawasm" {
-					args = append(args, "--signext-lowering")
+					args = append(args,
+						opt,
+						"--signext-lowering",
+						// "--signature-pruning",
+						// "--const-hoisting",
+						// "--mvp-features",
+						result.Executable,
+						"--output",
+						result.Executable,
+					)
+				} else {
+					args = append(args,
+						opt,
+						"-g",
+						result.Executable,
+						"--output",
+						result.Executable,
+					)
 				}
 
 				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
+
+				println(cmd.String())
 
 				err := cmd.Run()
 				if err != nil {

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -152,6 +152,8 @@ func (c *Config) OptLevel() (level string, speedLevel, sizeLevel int) {
 		return "O1", 1, 0
 	case "2":
 		return "O2", 2, 0
+	case "3":
+		return "O3", 2, 0
 	case "s":
 		return "Os", 2, 1
 	case "z":

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -13,7 +13,7 @@ var (
 	validSerialOptions        = []string{"none", "uart", "usb"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
-	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
+	validOptOptions           = []string{"none", "0", "1", "2", "3", "s", "z"}
 )
 
 // Options contains extra options to give to the compiler. These options are

--- a/main.go
+++ b/main.go
@@ -1406,7 +1406,7 @@ func main() {
 	}
 	command := os.Args[1]
 
-	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, s, z")
+	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, 3, s, z")
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, conservative)")
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, tasks, asyncify)")

--- a/polkawasm.sh
+++ b/polkawasm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build --tag tinygo/polkawasm:0.30.0 -f Dockerfile.polkawasm .
+docker run --rm -it tinygo/polkawasm:0.30.0 bash

--- a/src/machine/board_qtpy_esp32c3.go
+++ b/src/machine/board_qtpy_esp32c3.go
@@ -1,0 +1,60 @@
+//go:build qtpy_esp32c3
+
+// This file contains the pin mappings for the Adafruit QtPy ESP32C3 boards.
+//
+// https://learn.adafruit.com/adafruit-qt-py-esp32-c3-wifi-dev-board/pinouts
+package machine
+
+// Digital Pins
+const (
+	D0 = GPIO4
+	D1 = GPIO3
+	D2 = GPIO1
+	D3 = GPIO0
+)
+
+// Analog pins (ADC1)
+const (
+	A0 = GPIO4
+	A1 = GPIO3
+	A2 = GPIO1
+	A3 = GPIO0
+)
+
+// UART pins
+const (
+	RX_PIN = GPIO20
+	TX_PIN = GPIO21
+
+	UART_RX_PIN = RX_PIN
+	UART_TX_PIN = TX_PIN
+)
+
+// I2C pins
+const (
+	SDA_PIN = GPIO5
+	SCL_PIN = GPIO6
+
+	I2C0_SDA_PIN = SDA_PIN
+	I2C0_SCL_PIN = SCL_PIN
+)
+
+// SPI pins
+const (
+	SCK_PIN = GPIO10
+	MI_PIN  = GPIO8
+	MO_PIN  = GPIO7
+
+	SPI_SCK_PIN = SCK_PIN
+	SPI_SDI_PIN = MI_PIN
+	SPI_SDO_PIN = MO_PIN
+)
+
+const (
+	NEOPIXEL = GPIO2
+	WS2812   = GPIO2
+
+	// also used for boot button.
+	// set it to be an input-with-pullup
+	BUTTON = GPIO9
+)

--- a/src/machine/usb.go
+++ b/src/machine/usb.go
@@ -88,8 +88,9 @@ func strToUTF16LEDescriptor(in string, out []byte) {
 const cdcLineInfoSize = 7
 
 var (
-	ErrUSBReadTimeout = errors.New("USB read timeout")
-	ErrUSBBytesRead   = errors.New("USB invalid number of bytes read")
+	ErrUSBReadTimeout  = errors.New("USB read timeout")
+	ErrUSBBytesRead    = errors.New("USB invalid number of bytes read")
+	ErrUSBBytesWritten = errors.New("USB invalid number of bytes written")
 )
 
 var (

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows
+//go:build baremetal || js || windows || polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasi && !wasip1
+//go:build linux && !baremetal && !wasi && !wasip1 && !polkawasm
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux || wasip1
+//go:build darwin || (linux && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || wasip1 || windows
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || (linux && !polkawasm) || netbsd || openbsd || solaris || wasip1 || windows
 
 package os
 

--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,4 +1,4 @@
-//go:build !linux || baremetal
+//go:build !linux || baremetal || polkawasm
 
 package os
 

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 package os
 

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 package os_test
 

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi && !wasip1)
+//go:build baremetal || polkawasm || (wasm && !wasi && !wasip1)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/getpagesize_test.go
+++ b/src/os/getpagesize_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal) || wasip1
+//go:build windows || darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal) || wasip1
+//go:build windows || darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !baremetal && !js && !wasi && !wasip1
+//go:build !windows && !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/pipe_test.go
+++ b/src/os/pipe_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal && !wasi)
+//go:build windows || darwin || (linux && !baremetal && !wasi && !polkawasm)
 
 // Copyright 2021 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/read_test.go
+++ b/src/os/read_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi || wasip1
+//go:build baremetal || polkawasm || js || wasi || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_test.go
+++ b/src/os/removeall_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !js && !wasi)
+//go:build darwin || (linux && !baremetal && !js && !wasi && !polkawasm)
 
 // TODO: implement ReadDir on windows
 

--- a/src/os/seek_unix_bad.go
+++ b/src/os/seek_unix_bad.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi)
+//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi && !polkawasm)
 
 package os
 

--- a/src/os/stat_linuxlike.go
+++ b/src/os/stat_linuxlike.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal) || wasip1
+//go:build (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi && !wasip1)
+//go:build baremetal || polkawasm || (wasm && !wasi && !wasip1)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/arch_tinygowasm.go
+++ b/src/runtime/arch_tinygowasm.go
@@ -66,7 +66,7 @@ var (
 func align(ptr uintptr) uintptr {
 	// Align to 16, which is the alignment of max_align_t:
 	// https://godbolt.org/z/dYqTsWrGq
-	const heapAlign = 16
+	const heapAlign = 8
 	return (ptr + heapAlign - 1) &^ (heapAlign - 1)
 }
 

--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !custommalloc
+//go:build tinygo.wasm && !custommalloc && !polkawasm
 
 package runtime
 

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -1,11 +1,10 @@
 //go:build gc.custom
-// +build gc.custom
 
 package runtime
 
-// This GC strategy allows an external GC to be plugged in instead of the builtin
-// implementations.
-//
+// Simple GC, that calls an external allocator. It does not free memory, but works faster
+// and memory is freed at the end of the execution from the external allocator.
+
 // The interface defined in this file is not stable and can be broken at anytime, even
 // across minor versions.
 //
@@ -36,28 +35,100 @@ import (
 	"unsafe"
 )
 
-// initHeap is called when the heap is first initialized at program start.
-func initHeap()
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
 
-// alloc is called to allocate memory. layout is currently not used.
-func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+const gcFrees = 0
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// Heap is initialized by the external allocator
+}
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Heap is in custom GC, so ignore it when called from wasm initialization.
+}
+
+// alloc tries to find free space on the heap to allocate memory,
+// If no space is free, it panics. layout is currently not used.
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	printstr("call alloc(")
+	printnum(int(size))
+	printstr(")\n")
+
+	if size == 0 {
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	printstr("\ttotal memory ")
+	printnum(int(gcTotalAlloc))
+	printstr("\n")
+
+	size = align(size)
+
+	// Try to bound heap growth.
+	if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+		printstr("\tout of memory\n")
+		abort()
+	}
+
+	// Allocate the memory.
+	pointer := extalloc(size)
+	if pointer == nil {
+		printstr("\textalloc call failed\n")
+		abort()
+	}
+
+	// Zero-out the allocated memory
+	memzero(pointer, size)
+
+	// Update used memory
+	gcTotalAlloc += uint64(size)
+
+	return pointer
+}
 
 // free is called to explicitly free a previously allocated pointer.
-func free(ptr unsafe.Pointer)
+func free(ptr unsafe.Pointer) {
+	// memory is never freed from the GC, but from the
+	// external allocator at the end of the execution
+}
 
 // markRoots is called with the start and end addresses to scan for references.
 // It is currently only called with the top and bottom of the stack.
-func markRoots(start, end uintptr)
+func markRoots(start, end uintptr) {
+
+}
 
 // GC is called to explicitly run garbage collection.
-func GC()
+func GC() {
+
+}
 
 // SetFinalizer registers a finalizer.
-func SetFinalizer(obj interface{}, finalizer interface{})
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+
+}
 
 // ReadMemStats populates m with memory statistics.
-func ReadMemStats(ms *MemStats)
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
 
-func setHeapEnd(newHeapEnd uintptr) {
-	// Heap is in custom GC so ignore for when called from wasm initialization.
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
 }

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -1,4 +1,4 @@
-//go:build gc.custom
+//go:build gc.custom_wip
 
 package runtime
 
@@ -61,31 +61,21 @@ func setHeapEnd(newHeapEnd uintptr) {
 //
 //go:noinline
 func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
-	printstr("call alloc(")
-	printnum(int(size))
-	printstr(")\n")
-
 	if size == 0 {
 		return unsafe.Pointer(&zeroSizedAlloc)
 	}
 
-	printstr("\ttotal memory ")
-	printnum(int(gcTotalAlloc))
-	printstr("\n")
-
-	size = align(size)
+	size += align(unsafe.Sizeof(layout))
 
 	// Try to bound heap growth.
 	if gcTotalAlloc+uint64(size) < gcTotalAlloc {
-		printstr("\tout of memory\n")
 		abort()
 	}
 
 	// Allocate the memory.
 	pointer := extalloc(size)
 	if pointer == nil {
-		printstr("\textalloc call failed\n")
-		abort()
+		gcAllocPanic()
 	}
 
 	// Zero-out the allocated memory
@@ -105,19 +95,13 @@ func free(ptr unsafe.Pointer) {
 
 // markRoots is called with the start and end addresses to scan for references.
 // It is currently only called with the top and bottom of the stack.
-func markRoots(start, end uintptr) {
-
-}
+func markRoots(start, end uintptr) {}
 
 // GC is called to explicitly run garbage collection.
-func GC() {
-
-}
+func GC() {}
 
 // SetFinalizer registers a finalizer.
-func SetFinalizer(obj interface{}, finalizer interface{}) {
-
-}
+func SetFinalizer(obj interface{}, finalizer interface{}) {}
 
 // ReadMemStats populates m with memory statistics.
 func ReadMemStats(ms *MemStats) {

--- a/src/runtime/gc_custom_extalloc.go
+++ b/src/runtime/gc_custom_extalloc.go
@@ -1,0 +1,559 @@
+//go:build gc.custom_wip
+
+package runtime
+
+// WIP
+
+// This is a conservative collector which uses an external memory allocator.
+// It keeps a list of allocations for tracking purposes.
+
+// This GC strategy allows an external GC to be plugged in instead of the builtin
+// implementations.
+//
+// The interface defined in this file is not stable and can be broken at anytime, even
+// across minor versions.
+//
+// runtime.markStack() must be called at the beginning of any GC cycle. //go:linkname
+// on a function without a body can be used to access this internal function.
+//
+// The custom implementation must provide the following functions in the runtime package
+// using the go:linkname directive:
+//
+// - func initHeap()
+// - func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// - func free(ptr unsafe.Pointer)
+// - func markRoots(start, end uintptr)
+// - func GC()
+// - func SetFinalizer(obj interface{}, finalizer interface{})
+// - func ReadMemStats(ms *runtime.MemStats)
+//
+//
+// In addition, if targeting wasi, the following functions should be exported for interoperability
+// with wasi libraries that use them. Note, this requires the export directive, not go:linkname.
+//
+// - func malloc(size uintptr) unsafe.Pointer
+// - func free(ptr unsafe.Pointer)
+// - func calloc(nmemb, size uintptr) unsafe.Pointer
+// - func realloc(oldPtr unsafe.Pointer, size uintptr) unsafe.Pointer
+
+import (
+	"unsafe"
+)
+
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
+
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+var gcFrees uint64
+
+// This is used to detect if the collector is invoking itself or trying to allocate memory.
+var gcRunning bool
+
+// heapBound is used to control the growth of the heap.
+// When the heap exceeds this size, the garbage collector is run.
+// If the garbage collector cannot free up enough memory, the bound is doubled until the allocation fits.
+var heapBound uintptr = 4 * unsafe.Sizeof(unsafe.Pointer(nil))
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
+
+// scanQueue is a queue of marked allocations to scan.
+var scanQueue *allocListEntry
+
+var allocList []allocListEntry
+
+// allocListEntry is a listing of a single heap allocation.
+type allocListEntry struct {
+	start uintptr
+	end   uintptr
+	next  *allocListEntry
+}
+
+// scan marks all allocations referenced by this allocation.
+// This should only be invoked by the garbage collector.
+func (e *allocListEntry) scan() {
+	scan(e.start, e.end)
+}
+
+// scan loads all pointer-aligned words and marks any pointers that it finds.
+func scan(start uintptr, end uintptr) {
+	// Align start pointer.
+	start = (start + unsafe.Alignof(unsafe.Pointer(nil)) - 1) &^ (unsafe.Alignof(unsafe.Pointer(nil)) - 1)
+
+	// Mark all pointers.
+	for ptr := start; ptr+unsafe.Sizeof(unsafe.Pointer(nil)) <= end; ptr += unsafe.Alignof(unsafe.Pointer(nil)) {
+		mark(*(*uintptr)(unsafe.Pointer(ptr)))
+	}
+}
+
+// mark searches for an allocation containing the given address and marks it if found.
+func mark(addr uintptr) bool {
+	if len(allocList) == 0 {
+		// The heap is empty.
+		return false
+	}
+
+	if addr < allocList[0].start || addr > allocList[len(allocList)-1].end {
+		// Pointer is outside of allocated bounds.
+		return false
+	}
+
+	// Search the allocation list for this address.
+	alloc := searchAllocList(allocList, addr)
+	if alloc != nil && alloc.next == nil {
+		printstr("mark ")
+		printnum(int(addr))
+		printstr("\n")
+
+		// Push the allocation onto the scan queue.
+		next := scanQueue
+		if next == nil {
+			// Insert a loop so we can tell that this isn't marked.
+			next = alloc
+		}
+		scanQueue, alloc.next = alloc, next
+
+		return true
+	}
+
+	// The address does not reference an unmarked allocation.
+	return false
+}
+
+// searchAllocList searches a sorted alloc list for an address.
+// If the address is found in an allocation, a pointer to the corresponding entry is returned.
+// Otherwise, this returns nil.
+func searchAllocList(list []allocListEntry, addr uintptr) *allocListEntry {
+	for len(list) > 0 {
+		mid := len(list) / 2
+		switch {
+		case addr < list[mid].start:
+			list = list[:mid]
+		case addr > list[mid].end:
+			list = list[mid+1:]
+		default:
+			return &list[mid]
+		}
+	}
+
+	return nil
+}
+
+// sortAllocList sorts an allocation list using heapsort.
+//
+//go:noinline
+func sortAllocList(list []allocListEntry) {
+	// Turn the array into a max heap.
+	for i, v := range list {
+		// Repeatedly swap v up the heap until the node above is at a greater address (or the top of the heap is reached).
+		for i > 0 && v.start > list[(i-1)/2].start {
+			list[i] = list[(i-1)/2]
+			i = (i - 1) / 2
+		}
+		list[i] = v
+	}
+
+	// Repeatedly remove the max and place it at the end of the array.
+	for len(list) > 1 {
+		// Remove the max and place it at the end of the array.
+		list[0], list[len(list)-1] = list[len(list)-1], list[0]
+		list = list[:len(list)-1]
+
+		// Fix the position of the element we swapped into the root.
+		i := 0
+		for {
+			// Find the element that should actually be at this position.
+			max := i
+			if l := 2*i + 1; l < len(list) && list[l].start > list[max].start {
+				max = l
+			}
+			if r := 2*i + 2; r < len(list) && list[r].start > list[max].start {
+				max = r
+			}
+
+			if max == i {
+				// The element is where it is supposed to be.
+				break
+			}
+
+			// Swap this element down the heap.
+			list[i], list[max] = list[max], list[i]
+			i = max
+		}
+	}
+}
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// Heap is initialized by the external allocator
+}
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Heap is in custom GC, so ignore it when called from wasm initialization.
+}
+
+// alloc tries to find free space on the heap to allocate memory,
+// possibly doing a garbage collection cycle if needed. If no space
+// is free, it panics. layout is currently not used.
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	printstr("call alloc(")
+	printnum(int(size))
+	printstr(")\n")
+
+	if size == 0 {
+		printstr("zero-size allocation\n")
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	if gcRunning {
+		printstr("aborting, called alloc during GC cycle\n")
+		abort()
+	}
+
+	size = align(size)
+	gcMallocs++
+
+	var gcRan bool
+	for {
+		// Try to bound heap growth.
+		if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+			printstr("total memory")
+			printnum(int(gcTotalAlloc))
+			printstr("\n")
+			printstr("target heap size exceeds address space\n")
+			abort()
+		}
+
+		if gcTotalAlloc+uint64(size) > uint64(heapBound) {
+			if !gcRan {
+				printstr("reached the heap size limit\n")
+				// Run the garbage collector before growing the heap.
+				GC()
+				gcRan = true
+				continue
+			} else {
+				// Grow the heap bound to fit the allocation.
+				for heapBound != 0 && uintptr(gcTotalAlloc)+size > heapBound {
+					heapBound <<= 1
+				}
+				if heapBound == 0 {
+					// This is only possible on hosted 32-bit systems.
+					// Allow the heap bound to encompass everything.
+					heapBound = ^uintptr(0)
+				}
+				printstr("increased the heap size limit to ")
+				printnum(int(heapBound))
+				printstr("\n")
+			}
+		}
+
+		// Ensure that there is space in the alloc list.
+		if len(allocList) == cap(allocList) {
+			printstr("alloc list is full\n")
+
+			// Attempt to double the size of the alloc list.
+			newCap := 2 * uintptr(cap(allocList))
+			if newCap == 0 {
+				newCap = 1
+			}
+
+			printstr("increase the capacity from ")
+			printnum(cap(allocList))
+			printstr(" to ")
+			printnum(int(newCap))
+			printstr("\n")
+
+			// oldList := allocList
+
+			oldListHeader := (*struct {
+				ptr unsafe.Pointer
+				len uintptr
+				cap uintptr
+			})(unsafe.Pointer(&allocList))
+
+			printstr("old list\n")
+			printstr("\tstart ")
+			printnum(int(uintptr(oldListHeader.ptr)))
+			printstr("\tend ")
+			printnum(int(uintptr(oldListHeader.ptr) + oldListHeader.cap*unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			printstr("try to allocate memory for the new alloc list with size ")
+			printnum(int(newCap * unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			newListPtr := extalloc(newCap * unsafe.Sizeof(allocListEntry{}))
+			if newListPtr == nil {
+				printstr("call to extalloc failed")
+
+				if gcRan {
+					// Garbage collector was not able to free up enough memory.
+					printstr("out of memory\n")
+					abort()
+				} else {
+					// Run the garbage collector and try again.
+					GC()
+					gcRan = true
+					continue
+				}
+			}
+
+			newListHeader := (*struct {
+				ptr unsafe.Pointer
+				len uintptr
+				cap uintptr
+			})(unsafe.Pointer(&allocList))
+			newListHeader.ptr = newListPtr
+			newListHeader.len = oldListHeader.len // uintptr(len(oldList))
+			newListHeader.cap = newCap
+
+			// copy(allocList, oldList)
+			// for i := range oldList {
+			// 	*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = oldList[i]
+			// }
+			for i := 0; i < int(oldListHeader.len); i++ {
+				*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = *(*allocListEntry)(unsafe.Pointer(uintptr(oldListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{})))
+			}
+
+			printstr("new list\n")
+			printstr("\tstart ")
+			printnum(int(uintptr(newListHeader.ptr)))
+			printstr("\tend ")
+			printnum(int(uintptr(newListHeader.ptr) + newListHeader.cap*unsafe.Sizeof(allocListEntry{})))
+			printstr("\n")
+
+			if oldListHeader.cap != 0 { // cap(oldList)
+				printstr("free the old alloc list\n")
+				free(oldListHeader.ptr) // unsafe.Pointer(&oldList[0])
+			}
+		}
+
+		// Allocate the memory.
+		pointer := extalloc(size)
+		if pointer == nil {
+			printstr("\textalloc call failed\n")
+
+			if gcRan {
+				// Garbage collector was not able to free up enough memory.
+				printstr("out of memory\n")
+				abort()
+			} else {
+				// Run the garbage collector and try again.
+				GC()
+				gcRan = true
+				continue
+			}
+		}
+
+		// Add the allocation to the list.
+		i := len(allocList)
+		// allocList = allocList[:i+1]
+		// allocList[i] = allocListEntry{
+		// 	start: uintptr(pointer),
+		// 	end:   uintptr(pointer) + size,
+		// }
+
+		newListHeader := (*struct {
+			ptr unsafe.Pointer
+			len uintptr
+			cap uintptr
+		})(unsafe.Pointer(&allocList))
+
+		*(*allocListEntry)(unsafe.Pointer(uintptr(newListHeader.ptr) + uintptr(i)*unsafe.Sizeof(allocListEntry{}))) = allocListEntry{
+			start: uintptr(pointer),
+			end:   uintptr(pointer) + size,
+		}
+
+		newListHeader.len = uintptr(i + 1)
+
+		// printstr("updated new alloc list\n")
+		// printstr("\tlength ")
+		// printnum(len(allocList))
+		// printstr("\n")
+		// printstr("\tcapacity ")
+		// printnum(cap(allocList))
+		// printstr("\n")
+
+		// Zero-out the allocated memory
+		memzero(pointer, size)
+
+		// Update used memory
+		gcTotalAlloc += uint64(size)
+
+		printstr("total memory ")
+		printnum(int(gcTotalAlloc))
+		printstr("\n")
+
+		return pointer
+	}
+}
+
+// free is called to explicitly free a previously allocated pointer.
+func free(ptr unsafe.Pointer) {
+	printstr("call free(")
+	printnum(int(uintptr(ptr)))
+	printstr(")\n")
+	gcFrees++
+	extfree(ptr)
+}
+
+// markRoots is called with the start and end addresses to scan for references.
+// It is currently only called with the top and bottom of the stack.
+func markRoots(start, end uintptr) {
+	scan(start, end)
+}
+
+func markRoot(addr uintptr, root uintptr) {
+	mark(root)
+}
+
+// GC is called to explicitly run garbage collection.
+func GC() {
+	// printstr("call GC()\n")
+
+	// if gcRunning {
+	// 	printstr("aborting recursive GC() call\n")
+	// 	abort()
+	// }
+	// gcRunning = true
+
+	// printstr("non-sorted pre-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// // Sort the allocation list so that it can be efficiently searched.
+	// sortAllocList(allocList)
+
+	// // Unmark all allocations.
+	// for i := range allocList {
+	// 	allocList[i].next = nil
+	// }
+
+	// // Reset the scan queue.
+	// scanQueue = nil
+
+	// printstr("pre-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// if len(allocList) > 1 {
+	// 	for i, _ := range allocList[1:] {
+	// 		if allocList[i+1].start < allocList[i].start { // <= ?
+	// 			printstr("alloc list is not sorted\n")
+	// 			abort()
+	// 		}
+	// 	}
+	// }
+
+	// // Start by scanning the stack.
+	// // markStack()
+
+	// // Scan all globals.
+	// // markGlobals()
+
+	// // Channel operations in interrupts may move task pointers around while we are marking.
+	// // Therefore we need to scan the runqueue seperately.
+	// // 	var markedTaskQueue task.Queue
+	// // runqueueScan:
+	// // 	for !runqueue.Empty() {
+	// // 		// Pop the next task off of the runqueue.
+	// // 		t := runqueue.Pop()
+
+	// // 		// Mark the task if it has not already been marked.
+	// // 		markRoot(uintptr(unsafe.Pointer(&runqueue)), uintptr(unsafe.Pointer(t)))
+
+	// // 		// Push the task onto our temporary queue.
+	// // 		markedTaskQueue.Push(t)
+	// // 	}
+
+	// // Scan all referenced allocations.
+	// // for scanQueue != nil {
+	// // 	// Pop a marked allocation off of the scan queue.
+	// // 	alloc := scanQueue
+	// // 	next := alloc.next
+	// // 	if next == alloc {
+	// // 		// This is the last value on the queue.
+	// // 		next = nil
+	// // 	}
+	// // 	scanQueue = next
+
+	// // 	// Scan and mark all allocations that this references.
+	// // 	alloc.scan()
+	// // }
+
+	// // i := interrupt.Disable()
+	// // if !runqueue.Empty() {
+	// // 	// Something new came in while finishing the mark.
+	// // 	interrupt.Restore(i)
+	// // 	goto runqueueScan
+	// // }
+	// // runqueue = markedTaskQueue
+	// // interrupt.Restore(i)
+
+	// // Free all remaining unmarked allocations.
+	// // gcTotalAlloc = 0
+	// // j := 0
+	// // for _, v := range allocList {
+	// // 	if v.next == nil {
+	// // 		// This was never marked.
+	// // 		free(unsafe.Pointer(v.start))
+	// // 		continue
+	// // 	}
+
+	// // 	// Move this down in the list.
+	// // 	allocList[j] = v
+	// // 	j++
+
+	// // 	// Re-calculate used memory.
+	// // 	gcTotalAlloc += uint64(v.end - v.start)
+	// // }
+	// // allocList = allocList[:j]
+
+	// printstr("post-GC allocations\n")
+	// for _, v := range allocList {
+	// 	printstr("\t[")
+	// 	printnum(int(v.start))
+	// 	printstr(",")
+	// 	printnum(int(v.end))
+	// 	printstr("]\n")
+	// }
+	// printstr("\n")
+
+	// gcRunning = false
+}
+
+// SetFinalizer registers a finalizer.
+func SetFinalizer(obj interface{}, finalizer interface{}) {
+	// TODO
+}
+
+// ReadMemStats populates m with memory statistics.
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
+
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
+}

--- a/src/runtime/gc_debug.go
+++ b/src/runtime/gc_debug.go
@@ -1,0 +1,71 @@
+//go:build gc.custom || gc.custom_wip
+
+package runtime
+
+const gcDebug = false
+
+func printnum(num int) {
+	digits := [10]int{}
+
+	for i := 0; num > 0; i++ {
+		digit := num % 10
+		digits[i] = digit
+		num = num / 10
+	}
+
+	for i := 0; i < len(digits)/2; i++ {
+		j := len(digits) - i - 1
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+
+	skipZeros := true
+	for i := 0; i < len(digits); i++ {
+		digit := digits[i]
+		if skipZeros && digit == 0 {
+			continue
+		}
+		skipZeros = false
+
+		digitStr := ""
+
+		switch digit {
+		case 0:
+			digitStr = "0"
+		case 1:
+			digitStr = "1"
+		case 2:
+			digitStr = "2"
+		case 3:
+			digitStr = "3"
+		case 4:
+			digitStr = "4"
+		case 5:
+			digitStr = "5"
+		case 6:
+			digitStr = "6"
+		case 7:
+			digitStr = "7"
+		case 8:
+			digitStr = "8"
+		case 9:
+			digitStr = "9"
+		default:
+		}
+
+		printstr(digitStr)
+	}
+}
+
+func printstr(str string) {
+	if !gcDebug {
+		return
+	}
+
+	for i := 0; i < len(str); i++ {
+		if putcharPosition >= putcharBufferSize {
+			break
+		}
+
+		putchar(str[i])
+	}
+}

--- a/src/runtime/gc_debug.go
+++ b/src/runtime/gc_debug.go
@@ -1,58 +1,34 @@
-//go:build gc.custom || gc.custom_wip
+//go:build gc.custom
 
 package runtime
 
 const gcDebug = false
 
 func printnum(num int) {
-	digits := [10]int{}
-
-	for i := 0; num > 0; i++ {
-		digit := num % 10
-		digits[i] = digit
-		num = num / 10
+	if num == 0 {
+		printstr("0")
+		return
 	}
 
-	for i := 0; i < len(digits)/2; i++ {
-		j := len(digits) - i - 1
+	digits := [16]int{} // store up to 16 digits
+	digitStrings := [10]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+	count := 0 // count of digits
+
+	// extract digits from the number
+	for ; num > 0; num /= 10 {
+		digits[count] = num % 10
+		count++
+	}
+
+	// reverse the digits
+	for i := 0; i < count/2; i++ {
+		j := count - i - 1
 		digits[i], digits[j] = digits[j], digits[i]
 	}
 
-	skipZeros := true
-	for i := 0; i < len(digits); i++ {
-		digit := digits[i]
-		if skipZeros && digit == 0 {
-			continue
-		}
-		skipZeros = false
-
-		digitStr := ""
-
-		switch digit {
-		case 0:
-			digitStr = "0"
-		case 1:
-			digitStr = "1"
-		case 2:
-			digitStr = "2"
-		case 3:
-			digitStr = "3"
-		case 4:
-			digitStr = "4"
-		case 5:
-			digitStr = "5"
-		case 6:
-			digitStr = "6"
-		case 7:
-			digitStr = "7"
-		case 8:
-			digitStr = "8"
-		case 9:
-			digitStr = "9"
-		default:
-		}
-
-		printstr(digitStr)
+	// print each digit
+	for i := 0; i < count; i++ {
+		printstr(digitStrings[digits[i]])
 	}
 }
 

--- a/src/runtime/gc_globals.go
+++ b/src/runtime/gc_globals.go
@@ -1,4 +1,4 @@
-//go:build (gc.conservative || gc.precise) && (baremetal || tinygo.wasm)
+//go:build (gc.conservative || gc.precise || gc.custom) && (baremetal || tinygo.wasm)
 
 package runtime
 

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal && !nintendoswitch && !wasi
+//go:build linux && !baremetal && !nintendoswitch && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/os_other.go
+++ b/src/runtime/os_other.go
@@ -1,4 +1,4 @@
-//go:build linux && (baremetal || nintendoswitch || wasi)
+//go:build linux && (baremetal || nintendoswitch || wasi || polkawasm)
 
 // Other systems that aren't operating systems supported by the Go toolchain
 // need to pretend to be an existing operating system. Linux seems like a good

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -180,3 +180,15 @@ func divideByZeroPanic() {
 func blockingPanic() {
 	runtimePanicAt(returnAddress(0), "trying to do blocking operation in exported function")
 }
+
+func gcRunningPanic() {
+	runtimePanicAt(returnAddress(0), "gc: already running")
+}
+
+func gcAllocPanic() {
+	runtimePanicAt(returnAddress(0), "gc: failed to allocate")
+}
+
+func gcUnsortedAllocsPanic() {
+	runtimePanicAt(returnAddress(0), "gc: unsorted allocs")
+}

--- a/src/runtime/runtime_esp32c3.go
+++ b/src/runtime/runtime_esp32c3.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"device/esp"
 	"device/riscv"
+	"machine"
 	"runtime/volatile"
 	"unsafe"
 )
@@ -52,6 +53,10 @@ func main() {
 
 	// Configure interrupt handler
 	interruptInit()
+
+	// Initialize UART.
+	machine.USBCDC.Configure(machine.UARTConfig{})
+	machine.InitSerial()
 
 	// Initialize main system timer used for time.Now.
 	initTimer()

--- a/src/runtime/runtime_esp32xx.go
+++ b/src/runtime/runtime_esp32xx.go
@@ -10,22 +10,6 @@ import (
 
 type timeUnit int64
 
-func putchar(c byte) {
-	machine.Serial.WriteByte(c)
-}
-
-func getchar() byte {
-	for machine.Serial.Buffered() == 0 {
-		Gosched()
-	}
-	v, _ := machine.Serial.ReadByte()
-	return v
-}
-
-func buffered() int {
-	return machine.Serial.Buffered()
-}
-
 // Initialize .bss: zero-initialized global variables.
 // The .data section has already been loaded by the ROM bootloader.
 func clearbss() {
@@ -83,4 +67,20 @@ func sleepTicks(d timeUnit) {
 
 func exit(code int) {
 	abort()
+}
+
+func putchar(c byte) {
+	machine.Serial.WriteByte(c)
+}
+
+func getchar() byte {
+	for machine.Serial.Buffered() == 0 {
+		Gosched()
+	}
+	v, _ := machine.Serial.ReadByte()
+	return v
+}
+
+func buffered() int {
+	return machine.Serial.Buffered()
 }

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,17 +2,13 @@
 
 package runtime
 
-import (
-	"unsafe"
-)
-
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-}
+// //export _start
+// func _start() {
+// 	// These need to be initialized early so that the heap can be initialized.
+// 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+// 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+// 	run()
+// }
 
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -1,0 +1,77 @@
+//go:build polkawasm
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//export _start
+func _start() {
+	// These need to be initialized early so that the heap can be initialized.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	run()
+}
+
+// Abort executes the wasm 'unreachable' instruction.
+func abort() {
+	trap()
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	return []string{}
+}
+
+func putchar(c byte) {
+}
+
+func getchar() byte {
+	return 0
+}
+
+func buffered() int {
+	return 0
+}
+
+type timeUnit int64
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	panic("unimplemented: ticksToNanoseconds")
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	panic("unimplemented: nanosecondsToTicks")
+}
+
+func sleepTicks(d timeUnit) {
+	panic("unimplemented: sleepTicks")
+}
+
+func ticks() timeUnit {
+	panic("unimplemented: ticks")
+}
+
+//go:linkname now time.now
+func now() (int64, int32, int64) {
+	panic("unimplemented: now")
+}
+
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	return
+}
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+}

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,6 +2,8 @@
 
 package runtime
 
+import "unsafe"
+
 // //export _start
 // func _start() {
 // 	// These need to be initialized early so that the heap can be initialized.
@@ -10,22 +12,27 @@ package runtime
 // 	run()
 // }
 
+// Using global variables to avoid heap allocation.
+const putcharBufferSize = 256 // increase the debug output size
+
+var (
+	putcharBuffer        = [putcharBufferSize]byte{}
+	putcharPosition uint = 0
+)
+
+// //go:export _debug_buf
+// func debugBuf() uintptr {
+// 	return uintptr(unsafe.Pointer(&putcharBuffer[0]))
+// }
+
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
 }
 
-//go:linkname os_runtime_args os.runtime_args
-func os_runtime_args() []string {
-	return []string{}
-}
-
-//go:linkname syscall_runtime_envs syscall.runtime_envs
-func syscall_runtime_envs() []string {
-	return []string{}
-}
-
 func putchar(c byte) {
+	putcharBuffer[putcharPosition] = c
+	putcharPosition++
 }
 
 func getchar() byte {
@@ -55,8 +62,18 @@ func ticks() timeUnit {
 }
 
 //go:linkname now time.now
-func now() (int64, int32, int64) {
+func now() (sec int64, nsec int32, mono int64) {
 	panic("unimplemented: now")
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	panic("unimplemented: syscall_runtime_envs")
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
 }
 
 //go:linkname syscall_Exit syscall.Exit
@@ -66,8 +83,16 @@ func syscall_Exit(code int) {
 
 //go:linkname procPin sync/atomic.runtime_procPin
 func procPin() {
+
 }
 
 //go:linkname procUnpin sync/atomic.runtime_procUnpin
 func procUnpin() {
+
 }
+
+//go:wasmimport env ext_allocator_malloc_version_1
+func extalloc(size uintptr) unsafe.Pointer
+
+//go:wasmimport env ext_allocator_free_version_1
+func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -12,18 +12,18 @@ import "unsafe"
 // 	run()
 // }
 
+// //go:export _debug_buf
+// func debugBuf() uint64 {
+// 	return uint64(uintptr(unsafe.Pointer(&putcharBuffer[0]))) | (uint64(putcharBufferSize) << 32)
+// }
+
 // Using global variables to avoid heap allocation.
-const putcharBufferSize = 256 // increase the debug output size
+const putcharBufferSize = 16 // increase the debug output size
 
 var (
 	putcharBuffer        = [putcharBufferSize]byte{}
 	putcharPosition uint = 0
 )
-
-// //go:export _debug_buf
-// func debugBuf() uintptr {
-// 	return uintptr(unsafe.Pointer(&putcharBuffer[0]))
-// }
 
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm
+//go:build tinygo.wasm && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch
+//go:build (darwin || (linux && !baremetal && !wasi && !polkawasm)) && !nintendoswitch
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !wasip1
+//go:build wasm && !wasi && !wasip1 && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !scheduler.none && !wasip1
+//go:build wasm && !wasi && !polkawasm && !scheduler.none && !wasip1
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && (wasi || wasip1)
+//go:build tinygo.wasm && (wasi || wasip1) && !polkawasm
 
 package runtime
 

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1)
+//go:build baremetal || (wasm && !wasip1) || polkawasm
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !(baremetal || (wasm && !wasip1))
+//go:build !(baremetal || (wasm && !wasip1)) && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || tinygo.wasm
+//go:build baremetal || tinygo.wasm || polkawasm
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !tinygo.wasm
+//go:build !baremetal && !tinygo.wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || polkawasm
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js
+//go:build baremetal || nintendoswitch || js || polkawasm
 
 package syscall
 

--- a/targets/esp32c3.json
+++ b/targets/esp32c3.json
@@ -2,7 +2,7 @@
 	"inherits": ["riscv32"],
 	"features": "+32bit,+c,+m,-64bit,-a,-d,-e,-experimental-zawrs,-experimental-zca,-experimental-zcd,-experimental-zcf,-experimental-zihintntl,-experimental-ztso,-experimental-zvfh,-f,-h,-relax,-save-restore,-svinval,-svnapot,-svpbmt,-v,-xtheadvdot,-xventanacondops,-zba,-zbb,-zbc,-zbkb,-zbkc,-zbkx,-zbs,-zdinx,-zfh,-zfhmin,-zfinx,-zhinx,-zhinxmin,-zicbom,-zicbop,-zicboz,-zihintpause,-zk,-zkn,-zknd,-zkne,-zknh,-zkr,-zks,-zksed,-zksh,-zkt,-zmmul,-zve32f,-zve32x,-zve64d,-zve64f,-zve64x,-zvl1024b,-zvl128b,-zvl16384b,-zvl2048b,-zvl256b,-zvl32768b,-zvl32b,-zvl4096b,-zvl512b,-zvl64b,-zvl65536b,-zvl8192b",
 	"build-tags": ["esp32c3", "esp"],
-	"serial": "uart",
+	"serial": "usb",
 	"rtlib": "compiler-rt",
 	"libc": "picolibc",
 	"cflags": [

--- a/targets/m5stamp-c3.json
+++ b/targets/m5stamp-c3.json
@@ -1,6 +1,7 @@
 {
 	"inherits": ["esp32c3"],
 	"build-tags": ["m5stamp_c3"],
+	"serial": "uart",
 	"serial-port": ["1a86:55d4"]
 }
 

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "wasm32-unknown-polkawasm",
 	"cpu": "generic",
-	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features": "",
 	"build-tags": [
 		"tinygo.wasm",
 		"polkawasm",
@@ -14,11 +14,7 @@
 	"libc": "wasi-libc",
 	"scheduler": "none",
 	"default-stack-size": 16384,
-	"cflags": [
-		"-mbulk-memory",
-		"-mnontrapping-fptoint",
-		"-msign-ext"
-	],
+	"cflags": [],
 	"ldflags": [
 		"--initial-memory=1310720",
 		"--no-demangle",

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,9 +9,10 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
+	"gc": "conservative",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
-	"scheduler": "asyncify",
+	"scheduler": "none",
 	"default-stack-size": 16384,
 	"cflags": [
 		"-mbulk-memory",
@@ -19,8 +20,14 @@
 		"-msign-ext"
 	],
 	"ldflags": [
+		"--initial-memory=1310720",
+		"--no-demangle",
 		"--stack-first",
-		"--no-demangle"
+		"--import-memory",
+		"--allow-undefined",
+		"--export=__heap_base",
+		"--export=__data_end",
+		"--export-table"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -23,11 +23,12 @@
 		"--allow-undefined",
 		"--export=__heap_base",
 		"--export=__data_end",
-		"--export-table"
+		"--export-table",
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator": "wasmtime {}",
+	"emulator": "wasmtime --mapdir=/tmp::{tmpDir} {}",
 	"wasm-abi": "generic"
 }

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,0 +1,30 @@
+{
+	"llvm-target": "wasm32-unknown-polkawasm",
+	"cpu": "generic",
+	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"build-tags": [
+		"tinygo.wasm",
+		"polkawasm",
+		"runtime_memhash_leveldb"
+	],
+	"goos": "linux",
+	"goarch": "arm",
+	"linker": "wasm-ld",
+	"libc": "wasi-libc",
+	"scheduler": "asyncify",
+	"default-stack-size": 16384,
+	"cflags": [
+		"-mbulk-memory",
+		"-mnontrapping-fptoint",
+		"-msign-ext"
+	],
+	"ldflags": [
+		"--stack-first",
+		"--no-demangle"
+	],
+	"extra-files": [
+		"src/runtime/asm_tinygowasm.S"
+	],
+	"emulator": "wasmtime {}",
+	"wasm-abi": "generic"
+}

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,7 +9,7 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
-	"gc": "conservative",
+	"gc": "custom",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
 	"scheduler": "none",

--- a/targets/qtpy-esp32c3.json
+++ b/targets/qtpy-esp32c3.json
@@ -1,0 +1,4 @@
+{
+	"inherits": ["esp32c3"],
+	"build-tags": ["qtpy_esp32c3"]
+}


### PR DESCRIPTION
Custom implementation of a conservative, tracing (mark and sweep) garbage collector,
that relies on external memory allocator (via `ext_allocator_malloc, ext_allocator_free`) for the WebAssembly (polkawasm) target.

### Issue

https://github.com/LimeChain/gosemble/issues/194

## API
### alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
  * allocate memory with a requested size
    * [x] invoke `ext_allocator_malloc` provided by the host
  * keep track of each GC allocation in a separate global linked-list like structure (simplicity over performance)
    * [x] resize/move the list when the capacity is reached (allocate new bigger list by invoking `ext_allocator_malloc`)
    * [x] copy the old allocations
    * [x] update the list with new allocation
    * [x] free the old list 

### free(ptr unsafe.Pointer)
  * [x] invoke `ext_allocator_free` provided by the host

### GC()
 * [x] scan from the roots (globals, stack) to mark all referenced allocations 
 * [x] free the unmarked allocations (update the allocations list and the total amount of memory)

🐛  fix failing **_ExhaustsResourcesError** tests (`order from size: requested allocation too large, requested 201326592, max possible allocations: 134217728`). Our goscale codec could be contributing to the problem by causing a lot of heap allocations.

## Further Optimizations
* [ ] size optimizations with `wasm-opt` 
* [ ] employ a more efficient data structure for keeping track of heap allocations (in terms of search/insertion/deletion operations)
* [ ]  use wasi-libc `memcpy`
