### PR TITLE
New polkawasm target dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 	branch = main
 [submodule "lib/wasi-libc"]
 	path = lib/wasi-libc
-	url = https://github.com/WebAssembly/wasi-libc
+	url = https://github.com/LimeChain/wasi-libc
 [submodule "lib/picolibc"]
 	path = lib/picolibc
 	url = https://github.com/keith-packard/picolibc.git

--- a/Dockerfile.polkawasm
+++ b/Dockerfile.polkawasm
@@ -1,0 +1,33 @@
+# Diffs:
+# - prebuild LLVM
+
+FROM golang:1.21-bullseye AS tinygo-base
+
+ENV GO111MODULE=on
+ENV GOFLAGS="-buildvcs=false"
+
+# Add the LLVM 16 repo for Debian 11 Bullseye
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-16 main" | tee /etc/apt/sources.list.d/llvm.list
+
+# Install LLVM toolchain packages
+RUN apt-get update && apt-get install -y \
+  clang-16 lld-16 llvm-16-dev libclang-16-dev cmake ninja-build
+
+# Copy TinyGo repo
+COPY . /tinygo
+
+WORKDIR /tinygo/lib/binaryen
+
+# Install binaryen(wasm-opt) 
+RUN cmake . && make
+
+ENV WASMOPT="/tinygo/lib/binaryen/bin/wasm-opt"
+
+WORKDIR /tinygo
+
+# Build wasi-libc and tinygo compiler
+RUN make wasi-libc && \
+  go install .
+
+CMD ["tinygo"]

--- a/builder/build.go
+++ b/builder/build.go
@@ -823,6 +823,10 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					"--output", result.Executable,
 				)
 
+				if config.Target.Triple == "wasm32-unknown-polkawasm" {
+					args = append(args, "--signext-lowering")
+				}
+
 				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr

--- a/builder/build.go
+++ b/builder/build.go
@@ -816,20 +816,32 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 					args = append(args, "--asyncify")
 				}
 
-				args = append(args,
-					opt,
-					"-g",
-					result.Executable,
-					"--output", result.Executable,
-				)
-
 				if config.Target.Triple == "wasm32-unknown-polkawasm" {
-					args = append(args, "--signext-lowering")
+					args = append(args,
+						opt,
+						"--signext-lowering",
+						// "--signature-pruning",
+						// "--const-hoisting",
+						// "--mvp-features",
+						result.Executable,
+						"--output",
+						result.Executable,
+					)
+				} else {
+					args = append(args,
+						opt,
+						"-g",
+						result.Executable,
+						"--output",
+						result.Executable,
+					)
 				}
 
 				cmd := exec.Command(goenv.Get("WASMOPT"), args...)
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
+
+				println(cmd.String())
 
 				err := cmd.Run()
 				if err != nil {

--- a/compileopts/config.go
+++ b/compileopts/config.go
@@ -152,6 +152,8 @@ func (c *Config) OptLevel() (level string, speedLevel, sizeLevel int) {
 		return "O1", 1, 0
 	case "2":
 		return "O2", 2, 0
+	case "3":
+		return "O3", 2, 0
 	case "s":
 		return "Os", 2, 1
 	case "z":

--- a/compileopts/options.go
+++ b/compileopts/options.go
@@ -13,7 +13,7 @@ var (
 	validSerialOptions        = []string{"none", "uart", "usb"}
 	validPrintSizeOptions     = []string{"none", "short", "full"}
 	validPanicStrategyOptions = []string{"print", "trap"}
-	validOptOptions           = []string{"none", "0", "1", "2", "s", "z"}
+	validOptOptions           = []string{"none", "0", "1", "2", "3", "s", "z"}
 )
 
 // Options contains extra options to give to the compiler. These options are

--- a/main.go
+++ b/main.go
@@ -1406,7 +1406,7 @@ func main() {
 	}
 	command := os.Args[1]
 
-	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, s, z")
+	opt := flag.String("opt", "z", "optimization level: 0, 1, 2, 3, s, z")
 	gc := flag.String("gc", "", "garbage collector to use (none, leaking, conservative)")
 	panicStrategy := flag.String("panic", "print", "panic strategy (print, trap)")
 	scheduler := flag.String("scheduler", "", "which scheduler to use (none, tasks, asyncify)")

--- a/polkawasm.sh
+++ b/polkawasm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker build --tag tinygo/polkawasm:0.30.0 -f Dockerfile.polkawasm .
+docker run --rm -it tinygo/polkawasm:0.30.0 bash

--- a/src/os/dir_other.go
+++ b/src/os/dir_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || windows
+//go:build baremetal || js || windows || polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/dir_unix.go
+++ b/src/os/dir_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal && !wasi && !wasip1
+//go:build linux && !baremetal && !wasi && !wasip1 && !polkawasm
 
 package os
 

--- a/src/os/dirent_linux.go
+++ b/src/os/dirent_linux.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi
+//go:build !baremetal && !js && !wasi && !polkawasm
 
 // Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/env_unix_test.go
+++ b/src/os/env_unix_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || linux || wasip1
+//go:build darwin || (linux && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/exec_posix.go
+++ b/src/os/exec_posix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || linux || netbsd || openbsd || solaris || wasip1 || windows
+//go:build aix || darwin || dragonfly || freebsd || (js && wasm) || (linux && !polkawasm) || netbsd || openbsd || solaris || wasip1 || windows
 
 package os
 

--- a/src/os/executable_other.go
+++ b/src/os/executable_other.go
@@ -1,4 +1,4 @@
-//go:build !linux || baremetal
+//go:build !linux || baremetal || polkawasm
 
 package os
 

--- a/src/os/executable_procfs.go
+++ b/src/os/executable_procfs.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build linux && !baremetal
+//go:build linux && !baremetal && !polkawasm
 
 package os
 

--- a/src/os/file_anyos.go
+++ b/src/os/file_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Portions copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/file_anyos_test.go
+++ b/src/os/file_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 package os_test
 

--- a/src/os/file_other.go
+++ b/src/os/file_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi && !wasip1)
+//go:build baremetal || polkawasm || (wasm && !wasi && !wasip1)
 
 package os
 

--- a/src/os/file_unix.go
+++ b/src/os/file_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // target wasi sets GOOS=linux and thus the +linux build tag,
 // even though it doesn't show up in "tinygo info target -wasi"

--- a/src/os/getpagesize_test.go
+++ b/src/os/getpagesize_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal) || wasip1
+//go:build windows || darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/os_anyos_test.go
+++ b/src/os/os_anyos_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal) || wasip1
+//go:build windows || darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 package os_test
 

--- a/src/os/os_chmod_test.go
+++ b/src/os/os_chmod_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/os_symlink_test.go
+++ b/src/os/os_symlink_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !baremetal && !js && !wasi && !wasip1
+//go:build !windows && !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/pipe_test.go
+++ b/src/os/pipe_test.go
@@ -1,4 +1,4 @@
-//go:build windows || darwin || (linux && !baremetal && !wasi)
+//go:build windows || darwin || (linux && !baremetal && !wasi && !polkawasm)
 
 // Copyright 2021 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/read_test.go
+++ b/src/os/read_test.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_noat.go
+++ b/src/os/removeall_noat.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !baremetal && !js && !wasi && !wasip1
+//go:build !baremetal && !js && !wasi && !wasip1 && !polkawasm
 
 package os
 

--- a/src/os/removeall_other.go
+++ b/src/os/removeall_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js || wasi || wasip1
+//go:build baremetal || polkawasm || js || wasi || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/removeall_test.go
+++ b/src/os/removeall_test.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal && !js && !wasi)
+//go:build darwin || (linux && !baremetal && !js && !wasi && !polkawasm)
 
 // TODO: implement ReadDir on windows
 

--- a/src/os/seek_unix_bad.go
+++ b/src/os/seek_unix_bad.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi)
+//go:build (linux && !baremetal && 386) || (linux && !baremetal && arm && !wasi && !polkawasm)
 
 package os
 

--- a/src/os/stat_linuxlike.go
+++ b/src/os/stat_linuxlike.go
@@ -1,4 +1,4 @@
-//go:build (linux && !baremetal) || wasip1
+//go:build (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_other.go
+++ b/src/os/stat_other.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasi && !wasip1)
+//go:build baremetal || polkawasm || (wasm && !wasi && !wasip1)
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/stat_unix.go
+++ b/src/os/stat_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_anyos.go
+++ b/src/os/types_anyos.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !js
+//go:build !baremetal && !js && !polkawasm
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/os/types_unix.go
+++ b/src/os/types_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || (linux && !baremetal) || wasip1
+//go:build darwin || (linux && !baremetal && !polkawasm) || wasip1
 
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style

--- a/src/runtime/arch_tinygowasm_malloc.go
+++ b/src/runtime/arch_tinygowasm_malloc.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && !custommalloc
+//go:build tinygo.wasm && !custommalloc && !polkawasm
 
 package runtime
 

--- a/src/runtime/gc_custom.go
+++ b/src/runtime/gc_custom.go
@@ -1,11 +1,10 @@
-//go:build gc.custom
-// +build gc.custom
+//go:build gc.custom_wip
 
 package runtime
 
-// This GC strategy allows an external GC to be plugged in instead of the builtin
-// implementations.
-//
+// Simple GC, that calls an external allocator. It does not free memory, but works faster
+// and memory is freed at the end of the execution from the external allocator.
+
 // The interface defined in this file is not stable and can be broken at anytime, even
 // across minor versions.
 //
@@ -36,28 +35,84 @@ import (
 	"unsafe"
 )
 
-// initHeap is called when the heap is first initialized at program start.
-func initHeap()
+// Total amount allocated for runtime.MemStats
+var gcTotalAlloc uint64
 
-// alloc is called to allocate memory. layout is currently not used.
-func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// Total number of calls to alloc()
+var gcMallocs uint64
+
+// Total number of objected freed; for leaking collector this stays 0
+const gcFrees = 0
+
+// zeroSizedAlloc is just a sentinel that gets returned when allocating 0 bytes.
+var zeroSizedAlloc uint8
+
+// initHeap is called when the heap is first initialized at program start.
+func initHeap() {
+	// Heap is initialized by the external allocator
+}
+
+func setHeapEnd(newHeapEnd uintptr) {
+	// Heap is in custom GC, so ignore it when called from wasm initialization.
+}
+
+// alloc tries to find free space on the heap to allocate memory,
+// If no space is free, it panics. layout is currently not used.
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	if size == 0 {
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	size += align(unsafe.Sizeof(layout))
+
+	// Try to bound heap growth.
+	if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+		abort()
+	}
+
+	// Allocate the memory.
+	pointer := extalloc(size)
+	if pointer == nil {
+		gcAllocPanic()
+	}
+
+	// Zero-out the allocated memory
+	memzero(pointer, size)
+
+	// Update used memory
+	gcTotalAlloc += uint64(size)
+
+	return pointer
+}
 
 // free is called to explicitly free a previously allocated pointer.
-func free(ptr unsafe.Pointer)
+func free(ptr unsafe.Pointer) {
+	// memory is never freed from the GC, but from the
+	// external allocator at the end of the execution
+}
 
 // markRoots is called with the start and end addresses to scan for references.
 // It is currently only called with the top and bottom of the stack.
-func markRoots(start, end uintptr)
+func markRoots(start, end uintptr) {}
 
 // GC is called to explicitly run garbage collection.
-func GC()
+func GC() {}
 
 // SetFinalizer registers a finalizer.
-func SetFinalizer(obj interface{}, finalizer interface{})
+func SetFinalizer(obj interface{}, finalizer interface{}) {}
 
 // ReadMemStats populates m with memory statistics.
-func ReadMemStats(ms *MemStats)
+func ReadMemStats(ms *MemStats) {
+	ms.HeapIdle = 0
+	ms.HeapInuse = gcTotalAlloc
+	ms.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
 
-func setHeapEnd(newHeapEnd uintptr) {
-	// Heap is in custom GC so ignore for when called from wasm initialization.
+	ms.HeapSys = ms.HeapInuse + ms.HeapIdle
+	ms.GCSys = 0
+	ms.TotalAlloc = gcTotalAlloc
+	ms.Mallocs = gcMallocs
+	ms.Frees = gcFrees
+	ms.Sys = uint64(heapEnd - heapStart)
 }

--- a/src/runtime/gc_custom_extalloc.go
+++ b/src/runtime/gc_custom_extalloc.go
@@ -1,0 +1,523 @@
+//go:build gc.custom
+
+package runtime
+
+// This is an implementation of a conservative, tracing (mark and sweep) garbage collector,
+// that relies on external memory allocator for the WebAssembly (polkawasm) target.
+
+// The interface defined in this file is not stable and can be broken at anytime, even
+// across minor versions.
+//
+// runtime.markStack() must be called at the beginning of any GC cycle. //go:linkname
+// on a function without a body can be used to access this internal function.
+//
+// The custom implementation must provide the following functions in the runtime package
+// using the go:linkname directive:
+//
+// - func initHeap()
+// - func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer
+// - func free(ptr unsafe.Pointer)
+// - func markRoots(start, end uintptr)
+// - func GC()
+// - func SetFinalizer(obj interface{}, finalizer interface{})
+// - func ReadMemStats(ms *runtime.MemStats)
+
+import (
+	"unsafe"
+)
+
+// Flag used to detect if the collector is invoking itself recursively.
+var gcCollectorRunning bool
+
+// Total number of calls to alloc().
+var gcMallocs uint64
+
+// Total number of calls to free().
+var gcFrees uint64
+
+// Total amount of memory allocated on the heap, used
+// to bound the heap size.
+var gcTotalAlloc uint64
+
+// Controls the growth of the heap. When the heap exceeds
+// this size, the garbage collector is run. If the garbage
+// collector cannot free up enough memory, the bound is
+// doubled until the allocation fits.
+//
+// Size of a pointer on the target architecture (machine word size).
+var heapBound uintptr = 4 * unsafe.Sizeof(unsafe.Pointer(nil))
+
+// Gets returned when allocating zero-sized memory
+// to avoid returning nil pointers.
+var zeroSizedAlloc uint8
+
+// List of all allocations on the heap.
+var allocations []allocEntry
+
+// Queue of marked allocations that need to be scanned.
+var scanQueue *allocEntry
+
+// Representation of single heap allocation. Used to keep track
+// of all allocations and to find references between them.
+// start, end - object header (meta data) + data + padding
+// next - next allocation in the list of allocations
+type allocEntry struct {
+	start, end uintptr
+	next       *allocEntry
+}
+
+// Representation of a slice header (without the backing array).
+type SliceHeader struct {
+	ptr      unsafe.Pointer
+	len, cap uintptr
+}
+
+// The heap is initialized by the external allocator at program start.
+func initHeap() {}
+
+// The heap is in custom GC, so ignore it when called from wasm initialization
+func setHeapEnd(newHeapEnd uintptr) {}
+
+// Tries to find free space on the heap to allocate memory of the given size
+// and returns a pointer to it, possibly doing a garbage collection
+// cycle if needed. If no space is free, it panics
+//
+//go:noinline
+func alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer {
+	if gcCollectorRunning {
+		gcRunningPanic()
+	}
+
+	gcMallocs++
+
+	if size == 0 {
+		return unsafe.Pointer(&zeroSizedAlloc)
+	}
+
+	size += align(unsafe.Sizeof(layout))
+
+	var gcRan bool
+	for {
+		// Try to bound the heap size.
+		if gcTotalAlloc+uint64(size) < gcTotalAlloc {
+			abort()
+		}
+
+		if gcTotalAlloc+uint64(size) > uint64(heapBound) {
+			if !gcRan {
+				// Run the garbage collector before growing the heap.
+				GC()
+				gcRan = true
+				continue
+			} else {
+				// Grow the heap bound to fit the allocation.
+				for heapBound != 0 && uintptr(gcTotalAlloc)+size > heapBound {
+					heapBound <<= 1
+				}
+				if heapBound == 0 {
+					// This is only possible on hosted 32-bit systems.
+					// Allow the heap bound to encompass everything.
+					heapBound = ^uintptr(0)
+				}
+			}
+		}
+
+		// Keep a copy of the allocations list header
+		allocationsHeader := *getSliceHeader(&allocations)
+
+		// Ensure that there is enough space in the alloc list for the new allocations.
+		if allocationsHeader.len == allocationsHeader.cap {
+			// oldAllocations := allocations
+
+			// Attempt to double the capacity of the alloc list.
+			newCap := uintptr(double(int(allocationsHeader.cap)))
+
+			// Allocate new memory for the expanded slice
+			newAllocationsPtr := extalloc(newCap * allocEntrySize())
+			if newAllocationsPtr == nil {
+				if gcRan {
+					// Garbage collector was not able to free up enough memory.
+					gcAllocPanic()
+				} else {
+					// Run the garbage collector and try again.
+					GC()
+					gcRan = true
+					continue
+				}
+			}
+
+			newAllocationsHeader := getSliceHeader(&allocations)
+			setSliceHeader(newAllocationsHeader, newAllocationsPtr, allocationsHeader.len, newCap)
+
+			// Copy the old slice into the new slice
+			// memcpy(newAllocationsHeader.ptr, (&allocationsHeader).ptr, (&allocationsHeader).len)
+			copyAllocations(newAllocationsHeader, &allocationsHeader) // copy(allocations, oldAllocations)
+
+			if allocationsHeader.cap != 0 {
+				free(allocationsHeader.ptr) // unsafe.Pointer(&oldAllocations[0])
+			}
+		}
+
+		// Allocate the memory from the external allocator
+		ptr := extalloc(size)
+		if ptr == nil {
+			if gcRan {
+				// Garbage collector was not able to free up enough memory.
+				gcAllocPanic()
+			} else {
+				// Run the garbage collector and try again.
+				GC()
+				gcRan = true
+				continue
+			}
+		}
+
+		// Add the allocation to the list of allocations
+		// i := len(allocations); allocations = allocations[:i+1]; allocations[i] = newAllocEntry(ptr, size);
+		newAllocationsHeader := getSliceHeader(&allocations)
+		appendAllocations(newAllocationsHeader, newAllocEntry(ptr, size))
+
+		// Zero-out the allocated memory
+		memzero(ptr, size)
+
+		// Update the total allocated memory
+		gcTotalAlloc += uint64(size)
+
+		// Return the pointer to the allocated memory
+		return ptr
+	}
+}
+
+// Excplicitly frees previously allocated pointer.
+func free(ptr unsafe.Pointer) {
+	gcFrees++
+
+	// Free the memory
+	extfree(ptr)
+}
+
+// Scans for references on the stack and marks all reachable allocations.
+// It is currently only called with the top and bottom of the stack
+func markRoots(start, end uintptr) {
+	scan(start, end)
+}
+
+// func markRoot(addr, root uintptr) {
+// 	mark(root)
+// }
+
+// Performs a garbage collection cycle (mark and sweep).
+func GC() {
+	if gcCollectorRunning {
+		gcRunningPanic()
+	}
+	gcCollectorRunning = true
+
+	// The heap is empty
+	if len(allocations) == 0 {
+		gcCollectorRunning = false
+		return
+	}
+
+	// Sort the allocation list so that it can be searched efficiently
+	sortAllocations()
+
+	// Check that the allocation list is sorted
+	checkIfAllocationsSorted()
+
+	// Unmark all allocations in the allocation list
+	unmarkAllocations()
+
+	// Reset the scan queue
+	scanQueue = nil
+
+	// Scan the stack and mark all reachable allocations that are referenced by the stack roots (markStack).
+	markStack()
+
+	findGlobals(markRoots)
+
+	// 	var markedTaskQueue task.Queue
+	// 	// Channel operations in interrupts may move task pointers around while we are marking.
+	// 	// Therefore we need to scan the runqueue seperately.
+	// runqueueScan:
+	// 	for !runqueue.Empty() {
+	// 		// Pop the next task off of the runqueue.
+	// 		t := runqueue.Pop()
+
+	// 		// Mark the task if it has not already been marked.
+	// 		markRoot(uintptr(unsafe.Pointer(&runqueue)), uintptr(unsafe.Pointer(t)))
+
+	// 		// Push the task onto our temporary queue.
+	// 		markedTaskQueue.Push(t)
+	// 	}
+
+	finishMarking()
+
+	// // Restore the runqueue.
+	// i := interrupt.Disable()
+	// if !runqueue.Empty() {
+	// 	// Something new came in while finishing the mark.
+	// 	interrupt.Restore(i)
+	// 	goto runqueueScan
+	// }
+	// runqueue = markedTaskQueue
+	// interrupt.Restore(i)
+
+	// Remove and free all remaining unmarked allocations.
+	sweep()
+
+	gcCollectorRunning = false
+}
+
+// SetFinalizer registers a finalizer
+func SetFinalizer(obj interface{}, finalizer interface{}) {}
+
+// Populates the given MemStats struct with memory statistics
+func ReadMemStats(m *MemStats) {
+	m.HeapIdle = 0
+	m.HeapInuse = gcTotalAlloc
+	m.HeapReleased = 0 // always 0, we don't currently release memory back to the OS.
+
+	// ms.Sys = uint64(heapEnd - heapStart)
+	m.HeapSys = m.HeapInuse + m.HeapIdle
+	m.GCSys = 0
+	m.TotalAlloc = gcTotalAlloc
+	m.Mallocs = gcMallocs
+	m.Frees = gcFrees
+}
+
+// Scans all pointer-aligned words in a given range and marks any
+// pointers (allocations they point to) that it finds. Performs a
+// conservative scan, so it may mark allocations that are not
+// actually referenced.
+func scan(start, end uintptr) {
+	alignment := unsafe.Alignof(unsafe.Pointer(nil))
+
+	// Align the start pointer to the next pointer-aligned word.
+	start = (start + alignment - 1) &^ (alignment - 1)
+
+	// Mark all pointer aligned words in the given range.
+	for addr := start; addr+unsafe.Sizeof(unsafe.Pointer(nil)) <= end; addr += alignment {
+		mark(*(*uintptr)(unsafe.Pointer(addr)))
+	}
+
+	// // Mark the last word in the given range if it is pointer-aligned.
+	// if end&^(alignment-1) == end {
+	// 	mark(*(*uintptr)(unsafe.Pointer(end)))
+	// }
+}
+
+// Searches the allocation list for the given address (allocation containing the given address)
+// and marks the corresponding allocation if found
+func mark(addr uintptr) bool {
+	// The heap is empty
+	if len(allocations) == 0 {
+		return false
+	}
+
+	if addr < allocations[0].start || addr > allocations[len(allocations)-1].end {
+		// Pointer is outside of allocated bounds.
+		return false
+	}
+
+	// Search the allocation list for the address and mark it if found
+	curAlloc := searchAllocations(addr)
+
+	if curAlloc != nil && curAlloc.next == nil {
+		// Push the allocation onto the scan queue
+		nextAlloc := scanQueue
+
+		if nextAlloc == nil {
+			// Insert a loop, so we can tell that this isn't marked
+			nextAlloc = curAlloc
+		}
+
+		scanQueue, curAlloc.next = curAlloc, nextAlloc
+
+		return true
+	}
+
+	// The address does not reference an unmarked allocation
+	return false
+}
+
+func finishMarking() {
+	// Scan all allocations that are referenced by the scan queue.
+	// This is done in a loop, because scanning an allocation may
+	// add more allocations to the scan queue.
+	for scanQueue != nil {
+		// Pop a marked allocation off of the scan queue.
+		curAlloc := scanQueue
+		nextAlloc := curAlloc.next
+
+		// This is the last value on the queue.
+		if nextAlloc == curAlloc {
+			nextAlloc = nil
+		}
+
+		scanQueue = nextAlloc
+
+		// Scan and mark all allocations that are referenced
+		// by this allocation and adds them to the scan queue.
+		scan(curAlloc.start, curAlloc.end)
+	}
+}
+
+func sweep() {
+	gcTotalAlloc = 0
+	j := 0
+
+	for _, curAlloc := range allocations {
+		// This was never marked
+		if curAlloc.next == nil {
+			free(unsafe.Pointer(curAlloc.start))
+			continue
+		}
+		// Move this down in the list
+		allocations[j] = curAlloc
+		j++
+
+		// Re-calculate used memory.
+		gcTotalAlloc += uint64(curAlloc.end - curAlloc.start)
+	}
+
+	// 2. Remove the allocation from the list of allocations
+	allocations = allocations[:j]
+}
+
+// Unmarks all allocations in the allocation list.
+func unmarkAllocations() {
+	for i := range allocations {
+		allocations[i].next = nil
+	}
+}
+
+// Checks if the allocation list is sorted by start address.
+func checkIfAllocationsSorted() {
+	if len(allocations) > 1 {
+		for i := range allocations[1:] {
+			if allocations[i+1].start < allocations[i].start { // <=
+				gcUnsortedAllocsPanic()
+			}
+		}
+	}
+}
+
+// Sorts the allocation list by using heapsort (in-place)
+//
+//go:noinline
+func sortAllocations() {
+	// Turn the array into a max heap
+	for i := len(allocations)/2 - 1; i >= 0; i-- {
+		heapify(allocations, len(allocations), i)
+	}
+
+	// Heap sort
+	for end := len(allocations) - 1; end > 0; end-- {
+		// Swap the max element with the last item
+		allocations[0], allocations[end] = allocations[end], allocations[0]
+		// Restore the heap property
+		heapify(allocations, end, 0)
+	}
+}
+
+// heapify corrects the heap structure assuming children of i are already heaps
+func heapify(arr []allocEntry, n, i int) {
+	max := i
+	left := 2*i + 1
+	right := 2*i + 2
+
+	if left < n && arr[left].start > arr[max].start {
+		max = left
+	}
+
+	if right < n && arr[right].start > arr[max].start {
+		max = right
+	}
+
+	if max != i {
+		arr[i], arr[max] = arr[max], arr[i]
+		heapify(arr, n, max)
+	}
+}
+
+// Searches the allocations for the given address.
+// If the address is found in an allocation, a pointer
+// to the corresponding entry is returned.
+func searchAllocations(addr uintptr) *allocEntry {
+	low, high := 0, len(allocations)
+
+	for low < high {
+		mid := low + (high-low)/2
+
+		if addr < allocations[mid].start {
+			high = mid
+		} else if addr > allocations[mid].end {
+			low = mid + 1
+		} else {
+			return &allocations[mid]
+		}
+	}
+
+	return nil
+}
+
+// Returns a slice header for the given slice pointer.
+func getSliceHeader(list *[]allocEntry) *SliceHeader {
+	return (*SliceHeader)(unsafe.Pointer(list))
+}
+
+// Set the slice header to the given values.
+func setSliceHeader(header *SliceHeader, ptr unsafe.Pointer, len, cap uintptr) {
+	header.ptr = ptr
+	header.len = len
+	header.cap = cap
+}
+
+// Gets an allocation entry at the given offset in the allocations list.
+func getAllocationsEntry(header *SliceHeader, offset uintptr) allocEntry {
+	offsetPtr := unsafe.Add(header.ptr, offset*allocEntrySize())
+	return *(*allocEntry)(offsetPtr)
+}
+
+// Sets an allocation entry at the given offset in the allocations list.
+func setAllocationsEntry(header *SliceHeader, offset uintptr, entry allocEntry) {
+	offsetPtr := unsafe.Add(header.ptr, offset*allocEntrySize()) // unsafe.Sizeof(entry)
+	*(*allocEntry)(offsetPtr) = entry
+}
+
+// Appends an entry to the end of the allocations list.
+func appendAllocations(header *SliceHeader, entry allocEntry) {
+	offset := header.len
+	setAllocationsEntry(header, offset, entry)
+	header.len++
+	*(*SliceHeader)(unsafe.Pointer(&allocations)) = *header
+}
+
+// Copies all allocations from the source slice to the destination slice.
+func copyAllocations(dstHeader *SliceHeader, srcHeader *SliceHeader) {
+	for i := 0; i < int(srcHeader.len); i++ {
+		entry := getAllocationsEntry(srcHeader, uintptr(i))
+		setAllocationsEntry(dstHeader, uintptr(i), entry)
+	}
+}
+
+// Initializes new allocation entry with the given pointer and size.
+func newAllocEntry(ptr unsafe.Pointer, size uintptr) allocEntry {
+	return allocEntry{
+		start: uintptr(ptr),
+		end:   uintptr(ptr) + size,
+	}
+}
+
+// Size of single allocation entry.
+func allocEntrySize() uintptr {
+	return unsafe.Sizeof(allocEntry{})
+}
+
+func double(value int) int {
+	if value == 0 {
+		return 1
+	}
+	return 2 * value
+}

--- a/src/runtime/gc_debug.go
+++ b/src/runtime/gc_debug.go
@@ -1,0 +1,47 @@
+//go:build gc.custom
+
+package runtime
+
+const gcDebug = false
+
+func printnum(num int) {
+	if num == 0 {
+		printstr("0")
+		return
+	}
+
+	digits := [16]int{} // store up to 16 digits
+	digitStrings := [10]string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+	count := 0 // count of digits
+
+	// extract digits from the number
+	for ; num > 0; num /= 10 {
+		digits[count] = num % 10
+		count++
+	}
+
+	// reverse the digits
+	for i := 0; i < count/2; i++ {
+		j := count - i - 1
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+
+	// print each digit
+	for i := 0; i < count; i++ {
+		printstr(digitStrings[digits[i]])
+	}
+}
+
+func printstr(str string) {
+	if !gcDebug {
+		return
+	}
+
+	for i := 0; i < len(str); i++ {
+		if putcharPosition >= putcharBufferSize {
+			break
+		}
+
+		putchar(str[i])
+	}
+}

--- a/src/runtime/gc_globals.go
+++ b/src/runtime/gc_globals.go
@@ -1,4 +1,4 @@
-//go:build (gc.conservative || gc.precise) && (baremetal || tinygo.wasm)
+//go:build (gc.conservative || gc.precise || gc.custom) && (baremetal || tinygo.wasm)
 
 package runtime
 

--- a/src/runtime/os_linux.go
+++ b/src/runtime/os_linux.go
@@ -1,4 +1,4 @@
-//go:build linux && !baremetal && !nintendoswitch && !wasi
+//go:build linux && !baremetal && !nintendoswitch && !wasi && !polkawasm
 
 package runtime
 

--- a/src/runtime/os_other.go
+++ b/src/runtime/os_other.go
@@ -1,4 +1,4 @@
-//go:build linux && (baremetal || nintendoswitch || wasi)
+//go:build linux && (baremetal || nintendoswitch || wasi || polkawasm)
 
 // Other systems that aren't operating systems supported by the Go toolchain
 // need to pretend to be an existing operating system. Linux seems like a good

--- a/src/runtime/panic.go
+++ b/src/runtime/panic.go
@@ -180,3 +180,15 @@ func divideByZeroPanic() {
 func blockingPanic() {
 	runtimePanicAt(returnAddress(0), "trying to do blocking operation in exported function")
 }
+
+func gcRunningPanic() {
+	runtimePanicAt(returnAddress(0), "gc: already running")
+}
+
+func gcAllocPanic() {
+	runtimePanicAt(returnAddress(0), "gc: failed to allocate")
+}
+
+func gcUnsortedAllocsPanic() {
+	runtimePanicAt(returnAddress(0), "gc: unsorted allocs")
+}

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,17 +2,13 @@
 
 package runtime
 
-import (
-	"unsafe"
-)
-
-//export _start
-func _start() {
-	// These need to be initialized early so that the heap can be initialized.
-	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
-	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
-	run()
-}
+// //export _start
+// func _start() {
+// 	// These need to be initialized early so that the heap can be initialized.
+// 	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+// 	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+// 	run()
+// }
 
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -1,0 +1,77 @@
+//go:build polkawasm
+
+package runtime
+
+import (
+	"unsafe"
+)
+
+//export _start
+func _start() {
+	// These need to be initialized early so that the heap can be initialized.
+	heapStart = uintptr(unsafe.Pointer(&heapStartSymbol))
+	heapEnd = uintptr(wasm_memory_size(0) * wasmPageSize)
+	run()
+}
+
+// Abort executes the wasm 'unreachable' instruction.
+func abort() {
+	trap()
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	return []string{}
+}
+
+func putchar(c byte) {
+}
+
+func getchar() byte {
+	return 0
+}
+
+func buffered() int {
+	return 0
+}
+
+type timeUnit int64
+
+func ticksToNanoseconds(ticks timeUnit) int64 {
+	panic("unimplemented: ticksToNanoseconds")
+}
+
+func nanosecondsToTicks(ns int64) timeUnit {
+	panic("unimplemented: nanosecondsToTicks")
+}
+
+func sleepTicks(d timeUnit) {
+	panic("unimplemented: sleepTicks")
+}
+
+func ticks() timeUnit {
+	panic("unimplemented: ticks")
+}
+
+//go:linkname now time.now
+func now() (int64, int32, int64) {
+	panic("unimplemented: now")
+}
+
+//go:linkname syscall_Exit syscall.Exit
+func syscall_Exit(code int) {
+	return
+}
+
+//go:linkname procPin sync/atomic.runtime_procPin
+func procPin() {
+}
+
+//go:linkname procUnpin sync/atomic.runtime_procUnpin
+func procUnpin() {
+}

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -2,6 +2,8 @@
 
 package runtime
 
+import "unsafe"
+
 // //export _start
 // func _start() {
 // 	// These need to be initialized early so that the heap can be initialized.
@@ -10,22 +12,27 @@ package runtime
 // 	run()
 // }
 
+// //go:export _debug_buf
+// func debugBuf() uint64 {
+// 	return uint64(uintptr(unsafe.Pointer(&putcharBuffer[0]))) | (uint64(putcharBufferSize) << 32)
+// }
+
+// Using global variables to avoid heap allocation.
+const putcharBufferSize = 16 // increase the debug output size
+
+var (
+	putcharBuffer        = [putcharBufferSize]byte{}
+	putcharPosition uint = 0
+)
+
 // Abort executes the wasm 'unreachable' instruction.
 func abort() {
 	trap()
 }
 
-//go:linkname os_runtime_args os.runtime_args
-func os_runtime_args() []string {
-	return []string{}
-}
-
-//go:linkname syscall_runtime_envs syscall.runtime_envs
-func syscall_runtime_envs() []string {
-	return []string{}
-}
-
 func putchar(c byte) {
+	putcharBuffer[putcharPosition] = c
+	putcharPosition++
 }
 
 func getchar() byte {
@@ -55,8 +62,18 @@ func ticks() timeUnit {
 }
 
 //go:linkname now time.now
-func now() (int64, int32, int64) {
+func now() (sec int64, nsec int32, mono int64) {
 	panic("unimplemented: now")
+}
+
+//go:linkname syscall_runtime_envs syscall.runtime_envs
+func syscall_runtime_envs() []string {
+	panic("unimplemented: syscall_runtime_envs")
+}
+
+//go:linkname os_runtime_args os.runtime_args
+func os_runtime_args() []string {
+	return []string{}
 }
 
 //go:linkname syscall_Exit syscall.Exit
@@ -66,8 +83,16 @@ func syscall_Exit(code int) {
 
 //go:linkname procPin sync/atomic.runtime_procPin
 func procPin() {
+
 }
 
 //go:linkname procUnpin sync/atomic.runtime_procUnpin
 func procUnpin() {
+
 }
+
+//go:wasmimport env ext_allocator_malloc_version_1
+func extalloc(size uintptr) unsafe.Pointer
+
+//go:wasmimport env ext_allocator_free_version_1
+func extfree(ptr unsafe.Pointer)

--- a/src/runtime/runtime_tinygowasm.go
+++ b/src/runtime/runtime_tinygowasm.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm
+//go:build tinygo.wasm && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_unix.go
+++ b/src/runtime/runtime_unix.go
@@ -1,4 +1,4 @@
-//go:build (darwin || (linux && !baremetal && !wasi)) && !nintendoswitch
+//go:build (darwin || (linux && !baremetal && !wasi && !polkawasm)) && !nintendoswitch
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js.go
+++ b/src/runtime/runtime_wasm_js.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !wasip1
+//go:build wasm && !wasi && !wasip1 && !polkawasm
 
 package runtime
 

--- a/src/runtime/runtime_wasm_js_scheduler.go
+++ b/src/runtime/runtime_wasm_js_scheduler.go
@@ -1,4 +1,4 @@
-//go:build wasm && !wasi && !scheduler.none && !wasip1
+//go:build wasm && !wasi && !polkawasm && !scheduler.none && !wasip1
 
 package runtime
 

--- a/src/runtime/runtime_wasm_wasi.go
+++ b/src/runtime/runtime_wasm_wasi.go
@@ -1,4 +1,4 @@
-//go:build tinygo.wasm && (wasi || wasip1)
+//go:build tinygo.wasm && (wasi || wasip1) && !polkawasm
 
 package runtime
 

--- a/src/syscall/file_emulated.go
+++ b/src/syscall/file_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || (wasm && !wasip1)
+//go:build baremetal || (wasm && !wasip1) || polkawasm
 
 // This file emulates some file-related functions that are only available
 // under a real operating system.

--- a/src/syscall/file_hosted.go
+++ b/src/syscall/file_hosted.go
@@ -1,4 +1,4 @@
-//go:build !(baremetal || (wasm && !wasip1))
+//go:build !(baremetal || (wasm && !wasip1)) && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/proc_emulated.go
+++ b/src/syscall/proc_emulated.go
@@ -1,4 +1,4 @@
-//go:build baremetal || tinygo.wasm
+//go:build baremetal || tinygo.wasm || polkawasm
 
 // This file emulates some process-related functions that are only available
 // under a real operating system.

--- a/src/syscall/proc_hosted.go
+++ b/src/syscall/proc_hosted.go
@@ -1,4 +1,4 @@
-//go:build !baremetal && !tinygo.wasm
+//go:build !baremetal && !tinygo.wasm && !polkawasm
 
 // This file assumes there is a libc available that runs on a real operating
 // system.

--- a/src/syscall/syscall_nonhosted.go
+++ b/src/syscall/syscall_nonhosted.go
@@ -1,4 +1,4 @@
-//go:build baremetal || js
+//go:build baremetal || js || polkawasm
 
 package syscall
 

--- a/src/syscall/tables_nonhosted.go
+++ b/src/syscall/tables_nonhosted.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build baremetal || nintendoswitch || js
+//go:build baremetal || nintendoswitch || js || polkawasm
 
 package syscall
 

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,7 +1,7 @@
 {
 	"llvm-target": "wasm32-unknown-polkawasm",
 	"cpu": "generic",
-	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"features": "",
 	"build-tags": [
 		"tinygo.wasm",
 		"polkawasm",
@@ -14,11 +14,7 @@
 	"libc": "wasi-libc",
 	"scheduler": "none",
 	"default-stack-size": 16384,
-	"cflags": [
-		"-mbulk-memory",
-		"-mnontrapping-fptoint",
-		"-msign-ext"
-	],
+	"cflags": [],
 	"ldflags": [
 		"--initial-memory=1310720",
 		"--no-demangle",

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,9 +9,10 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
+	"gc": "conservative",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
-	"scheduler": "asyncify",
+	"scheduler": "none",
 	"default-stack-size": 16384,
 	"cflags": [
 		"-mbulk-memory",
@@ -19,8 +20,14 @@
 		"-msign-ext"
 	],
 	"ldflags": [
+		"--initial-memory=1310720",
+		"--no-demangle",
 		"--stack-first",
-		"--no-demangle"
+		"--import-memory",
+		"--allow-undefined",
+		"--export=__heap_base",
+		"--export=__data_end",
+		"--export-table"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -23,11 +23,12 @@
 		"--allow-undefined",
 		"--export=__heap_base",
 		"--export=__data_end",
-		"--export-table"
+		"--export-table",
+		"--no-entry"
 	],
 	"extra-files": [
 		"src/runtime/asm_tinygowasm.S"
 	],
-	"emulator": "wasmtime {}",
+	"emulator": "wasmtime --mapdir=/tmp::{tmpDir} {}",
 	"wasm-abi": "generic"
 }

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -1,0 +1,30 @@
+{
+	"llvm-target": "wasm32-unknown-polkawasm",
+	"cpu": "generic",
+	"features": "+bulk-memory,+nontrapping-fptoint,+sign-ext",
+	"build-tags": [
+		"tinygo.wasm",
+		"polkawasm",
+		"runtime_memhash_leveldb"
+	],
+	"goos": "linux",
+	"goarch": "arm",
+	"linker": "wasm-ld",
+	"libc": "wasi-libc",
+	"scheduler": "asyncify",
+	"default-stack-size": 16384,
+	"cflags": [
+		"-mbulk-memory",
+		"-mnontrapping-fptoint",
+		"-msign-ext"
+	],
+	"ldflags": [
+		"--stack-first",
+		"--no-demangle"
+	],
+	"extra-files": [
+		"src/runtime/asm_tinygowasm.S"
+	],
+	"emulator": "wasmtime {}",
+	"wasm-abi": "generic"
+}

--- a/targets/polkawasm.json
+++ b/targets/polkawasm.json
@@ -9,7 +9,7 @@
 	],
 	"goos": "linux",
 	"goarch": "arm",
-	"gc": "conservative",
+	"gc": "custom",
 	"linker": "wasm-ld",
 	"libc": "wasi-libc",
 	"scheduler": "none",


### PR DESCRIPTION
# Target 🎯 

New `polkawasm` target, targeting standalone **Wasm MVP** (similar to Rust's `wasm32-unknown-unknown`), but also incorporating **custom GC** that utilizes an external allocator (as per Polkadot specification).
Based on Tinygo 0.31.0 dev.

## Wasm ⚙️  

- [x] add custom Dockerfile and build script (with pre-build llvm)
- [x] add target implementation separate from the existing `wasm/wasi`
- [x] allow undefined (custom exported functions)
- [x] export globals and tables (`__heap_base`, `__data_end`)
- [x] import memory
- [ ] ~~change stack placement~~(no need, for now)
- [x] disable the scheduler (remove the support of goroutines and channels)
- [x] use `wasi-libc` with bulk memory ops disabled [wasi-libc pr](https://github.com/LimeChain/wasi-libc/pull/1) instead of providing own implementation. Not using `-opt=0` drops the size significantly and improves the performance.
- [x] remove `_start` export (not supported from the host and not required with the `custom extalloc gc`)
- [x] remove `wasm-libc` exported allocation functions
- [x] lower away the sign extension operations `--signext-lowering` in `wasm-opt`

## GC 🗑️ 

Custom implementation of a conservative, tracing (mark and sweep) garbage collector that relies on an external memory allocator (via `ext_allocator_malloc`, `ext_allocator_free`) for the WebAssembly (polkawasm) target. There is also a leaking GC implementation that only allocates memory through the external allocator but never frees it (not a real GC), however, it is useful for testing purposes and performance comparisons.

### API
#### `alloc(size uintptr, layout unsafe.Pointer) unsafe.Pointer`
  * [x] allocate memory with a requested size (invoke `ext_allocator_malloc` provided by the host)
  * [x] keep track of each GC allocation in a separate global linked-list like structure (simplicity over performance)
  * [x] resize/move the list when the capacity is reached (allocate new bigger list by invoking `ext_allocator_malloc`)

#### `free(ptr unsafe.Pointer)`
  * [x] invoke `ext_allocator_free` provided by the host

#### `GC()`
 * [x] scan from the roots (globals, stack) to mark all referenced allocations 
 * [x] free the unmarked allocations (update the allocations list and the total amount of memory)

🐛  fix failing **_ExhaustsResourcesError** tests (`order from size: requested allocation too large, requested 201326592, max possible allocations: 134217728`). Our goscale codec could be contributing to the problem by causing a lot of heap allocations.

### Further Optimizations 🪛 
* [ ] size optimizations with `wasm-opt` 
* [ ]  use wasi-libc `memcpy`
* [ ] employ a more efficient data structure for keeping track of heap allocations (in terms of search/insertion/deletion operations)
* [ ] add tests

### Related Issues ⚠️
default gc - https://github.com/LimeChain/gosemble/issues/96
scale/allocator bug - https://github.com/LimeChain/gosemble/issues/134
fmt/allocator bug - https://github.com/LimeChain/gosemble/issues/147
buffer bug - https://github.com/LimeChain/gosemble/issues/148
refactored allocator - https://github.com/LimeChain/gosemble/pull/285
new gc - https://github.com/LimeChain/gosemble/issues/194
