### PR TITLE
fix panicking and stack traces

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -819,6 +819,7 @@ func Build(pkgName, outpath, tmpdir string, config *compileopts.Config) (BuildRe
 				if config.Target.Triple == "wasm32-unknown-polkawasm" {
 					args = append(args,
 						opt,
+						"-g",
 						"--signext-lowering",
 						// "--signature-pruning",
 						// "--const-hoisting",

--- a/src/runtime/gc_debug.go
+++ b/src/runtime/gc_debug.go
@@ -42,6 +42,7 @@ func printstr(str string) {
 			break
 		}
 
-		putchar(str[i])
+		putcharBuffer[putcharPosition] = str[i]
+		putcharPosition++
 	}
 }

--- a/src/runtime/runtime_polkawasm.go
+++ b/src/runtime/runtime_polkawasm.go
@@ -30,10 +30,7 @@ func abort() {
 	trap()
 }
 
-func putchar(c byte) {
-	putcharBuffer[putcharPosition] = c
-	putcharPosition++
-}
+func putchar(c byte) {}
 
 func getchar() byte {
 	return 0


### PR DESCRIPTION
* [x] revert the wasm-opt flag for better stack traces (related [add support for passing the -g flag to wasm-opt](https://github.com/LimeChain/gosemble/issues/321)
* [x] fix misused putchar function